### PR TITLE
fix: add phi-psi case in _is_dims_match_coordinate_convert

### DIFF
--- a/src/arpes/utilities/conversion/grids.py
+++ b/src/arpes/utilities/conversion/grids.py
@@ -119,6 +119,7 @@ def _is_dims_match_coordinate_convert(
         ("theta",),
         ("beta",),
         ("phi", "theta"),
+        ("phi", "psi"),
         ("beta", "phi"),
         ("hv", "phi"),
         ("hv",),


### PR DESCRIPTION
Just one line added in grids.py to fix the k-conversion.