### PR TITLE
Excepting HTTPError when Notebook information cannot be read

### DIFF
--- a/src/arpes/utilities/jupyter.py
+++ b/src/arpes/utilities/jupyter.py
@@ -17,6 +17,7 @@ from IPython.core.interactiveshell import InteractiveShell
 from jupyter_server import serverapp
 from tqdm.notebook import tqdm
 from traitlets.config import MultipleInstanceError
+from urllib.error import HTTPError
 
 from arpes.config import CONFIG
 
@@ -127,6 +128,8 @@ def get_full_notebook_information() -> NoteBookInfomation | None:
                     }
         except (KeyError, TypeError):
             pass
+        except HTTPError:
+            logger.debug("Could not read notebook information")
     return None
 
 


### PR DESCRIPTION
As a an easy but not perfect fix to #47 the HTTPError that is raised is simply excepted. This allows importing arpes, but in the logs the Notebooks appear as "unnamed".