### PR TITLE
Update required ruff version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ build-backend = "hatchling.build"
 managed = true
 dev-dependencies = [
   "colorama>=0.4.6",
-  "ruff>=0.3.3",
+  "ruff>=0.8.0",
   "pytest>=7.3.2",
   "pytest-cov",
   "pytest-clarity",
@@ -113,7 +113,6 @@ exclude = ["scripts", "docs", "conda"]
 ignore = [
   "PD",     # pandas-vet
   "PD011",  # pandas-use-of-dot-values
-  "ANN101", # missing-type-self (ANN101)
   "N802",   # invalid-function-name (N802)
   "N806",   # non-lowercase-variable-in-function
   "N999",   # invalid-module-name (N999)

--- a/src/arpes/analysis/general.py
+++ b/src/arpes/analysis/general.py
@@ -201,7 +201,7 @@ def rebin(
     When both ``shape`` and ``bin_width`` are supplied, ``shape`` is used.
 
     Dimensions corresponding to missing entries in ``shape`` or ``reduction`` will not
-    be changed.
+    be changed
 
     Args:
         data: ARPES data
@@ -217,9 +217,9 @@ def rebin(
         The rebinned data.
     """
     bin_width = bin_width or {}
-    for k in kwargs:
+    for k, v in kwargs.items():
         if k in data.dims:
-            bin_width[k] = kwargs[k]
+            bin_width[k] = v
     if shape is None:
         shape = {}
         for k, v in bin_width.items():


### PR DESCRIPTION
As ANN101 is removed from ruff 8.00, the required version of ruff should be set at 8.00.