### PR TITLE
feat: 🎸 Remove S.transpose_to_front/back

### DIFF
--- a/legacy_files/widgets.py
+++ b/legacy_files/widgets.py
@@ -639,7 +639,7 @@ def pca_explorer(  # noqa: C901, PLR0915  # Might be removed in the future.
         """
         for_scatter = pca.isel(
             {component_dim: context["selected_components"]},
-        ).S.transpose_to_back(component_dim)
+        ).transpose(..., component_dim)
 
         size: NDArray[np.float64] = data.mean(other_dims).stack(pca_dims=pca_dims).values
         norm = np.expand_dims(np.linalg.norm(pca.values, axis=(0,)), axis=-1)
@@ -796,7 +796,7 @@ def kspace_tool(  # noqa: PLR0915, C901 # Might be removed in the future.
         data.coords["eV"] = 0
 
     if "eV" in data.dims:
-        data.S.transpose_to_front("eV")
+        data.transpose("eV", ...)
     data = data.copy(deep=True)
 
     ctx: CurrentContext = {"original_data": original_data, "data": data, "widgets": []}

--- a/src/arpes/analysis/decomposition.py
+++ b/src/arpes/analysis/decomposition.py
@@ -136,7 +136,7 @@ def decomposition_along(
         flattened_data: xr.DataArray = data.stack(fit_axis=axes)
         stacked = True
     else:
-        flattened_data = data.S.transpose_to_back(axes[0])
+        flattened_data = data.transpose(..., axes[0])
         stacked = False
 
     if len(flattened_data.dims) != TWO_DIMENSION:

--- a/src/arpes/analysis/gap.py
+++ b/src/arpes/analysis/gap.py
@@ -193,7 +193,7 @@ def _shift_energy_interpolate(
     shift: xr.DataArray | None = None,
 ) -> xr.DataArray:
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    data_arr = data.S.transpose_to_front("eV")
+    data_arr = data.transpose("eV", ...)
 
     new_data = data_arr.copy(deep=True)
     new_axis = new_data.coords["eV"]
@@ -253,7 +253,7 @@ def symmetrize(
         The symmetrized data.
     """
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    data = data.S.transpose_to_front("eV")
+    data = data.transpose("eV", ...)
 
     if subpixel or full_spectrum:
         data = _shift_energy_interpolate(data)

--- a/src/arpes/plotting/basic.py
+++ b/src/arpes/plotting/basic.py
@@ -57,7 +57,7 @@ def make_overview(
     ax: list[Axes] = []
     for i, spectrum in enumerate(data_all):
         ax.append(fig.add_subplot(nrows, ncols, i + 1))
-        spectrum.S.transpose_to_front("eV").plot(
+        spectrum.transpose("eV", ...).plot(
             ax=ax[i],
             add_labels=False,
             add_colorbar=False,

--- a/src/arpes/plotting/holoviews.py
+++ b/src/arpes/plotting/holoviews.py
@@ -233,13 +233,13 @@ def fit_inspection(
 
     assert "data" in dataset.data_vars
     arpes_measured: xr.DataArray = _fix_xarray_to_fit_with_holoview(
-        dataset.data.S.transpose_to_back("eV"),
+        dataset.data.transpose(..., "eV"),
     )
     fit = arpes_measured + _fix_xarray_to_fit_with_holoview(
-        dataset.residual.S.transpose_to_back("eV"),
+        dataset.residual.transpose(..., "eV"),
     )
     residual = _fix_xarray_to_fit_with_holoview(
-        dataset.residual.S.transpose_to_back("eV"),
+        dataset.residual.transpose(..., "eV"),
     )
     max_coords = arpes_measured.G.argmax_coords()
     posx = hv.streams.PointerX(x=max_coords[arpes_measured.dims[0]])

--- a/src/arpes/xarray_extensions.py
+++ b/src/arpes/xarray_extensions.py
@@ -1260,7 +1260,7 @@ class ARPESProperty(ARPESPropertyBase):
 
                 for i, plot_var in enumerate(to_plot):
                     spectrum = self._obj[plot_var]
-                    spectrum.S.transpose_to_front("eV").plot(ax=ax[i])
+                    spectrum.transpose("eV", ...).plot(ax=ax[i])
                     fancy_labels(ax[i])
                     ax[i].set_title(plot_var.replace("_", " "))
 
@@ -1269,7 +1269,7 @@ class ARPESProperty(ARPESPropertyBase):
         elif 1 <= len(self._obj.dims) < 3:  # noqa: PLR2004
             _, ax = plt.subplots(1, 1, figsize=(4, 3))
             spectrum = self._obj
-            spectrum.S.transpose_to_front("eV").plot(ax=ax)
+            spectrum.transpose("eV", ...).plot(ax=ax)
             fancy_labels(ax, data=self._obj)
             ax.set_title("")
 
@@ -1322,7 +1322,7 @@ class ARPESAccessorBase(ARPESProperty):
         """
         return [n for n in dir(self) if name in n]
 
-    def transpose_to_front(self, dim: str) -> XrTypes:
+    def transpose_to_front(self, dim: str) -> XrTypes:  # pragma: no cover
         """Transpose the dimensions (to front).
 
         Args:
@@ -1342,7 +1342,7 @@ class ARPESAccessorBase(ARPESProperty):
         dims.remove(dim)
         return self._obj.transpose(*([dim, *dims]))
 
-    def transpose_to_back(self, dim: str) -> XrTypes:
+    def transpose_to_back(self, dim: str) -> XrTypes:  # pragma: no cover
         """Transpose the dimensions (to back).
 
         Args:

--- a/tests/test_xarray_extensions.py
+++ b/tests/test_xarray_extensions.py
@@ -79,16 +79,6 @@ class TestforProperties:
             ),
         )
 
-    def test_transpose_front_back(self, dataarray_cut: xr.DataArray) -> None:
-        """Test for transpose_to_front/back."""
-        original_ndarray = dataarray_cut.values
-        transpose_to_front_ndarray = dataarray_cut.S.transpose_to_front("eV").values
-        transpose_to_back_ndarray = (
-            dataarray_cut.S.transpose_to_front("eV").S.transpose_to_back("eV").values
-        )
-        np.testing.assert_allclose(original_ndarray, transpose_to_front_ndarray.T)
-        np.testing.assert_allclose(original_ndarray, transpose_to_back_ndarray)
-
     def test_property_for_degrees_of_freedom(
         self,
         dataset_cut: xr.Dataset,


### PR DESCRIPTION
transpose_to_front/back can be replaced standard array
by transpose(dim, ...) / transpose(..., dim)

after XArray 0.14.