### PR TITLE
Tests for 3D map data loading using DSNP_UMCS plugin 

### DIFF
--- a/src/arpes/endstations/plugin/DSNP_UMCS.py
+++ b/src/arpes/endstations/plugin/DSNP_UMCS.py
@@ -157,6 +157,7 @@ class DSNP_UMCSEndstation(  # noqa: N801
         """Perform final processing on the ARPES data.
 
         - Add missing parameters.
+        - Convert notation to binding energy.
 
         Args:
             data(xr.Dataset): ARPES data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,7 @@ SCAN_FIXTURE_LOCATIONS = {
     "basic/MAESTRO_nARPES_focus_17.fits": "BL7-nano",
     "basic/Uranos_cut.pxt": "Uranos",
     "basic/DSNP_UMCS_cut.xy": "DSNP_UMCS",
+    "basic/DSNP_UMCS_map.xy": "DSNP_UMCS",
 }
 
 

--- a/tests/test_basic_data_loading.py
+++ b/tests/test_basic_data_loading.py
@@ -839,6 +839,28 @@ class TestBasicDataLoading:
                 },
             },
         ),
+        # DSNP_UMCS, map data
+        (
+            "dsnp_umcs_load_map",
+            {
+                "file": "basic/DSNP_UMCS_map.xy",
+                "expected": {
+                    "dims": ["eV", "phi", "theta"],
+                    "coords": {
+                        "x": 78.0,
+                        "y": 0.5,
+                        "z": 2.5,
+                        "beta": 0.0,
+                        "alpha": np.deg2rad(90),
+                        "psi": 0.0,
+                        "eV": [-1.5, 0.24313, 0.012817],
+                        "phi": [-0.120683, 0.120683, 0.00298],
+                        "theta": [np.deg2rad(-68.0), np.deg2rad(-45.0), np.deg2rad(0.2)],
+                    },
+                    "offset_coords": {},
+                },
+            },
+        ),
     ]
 
     def test_load_file_and_basic_attributes(

--- a/tests/test_prodigy_xy.py
+++ b/tests/test_prodigy_xy.py
@@ -28,6 +28,8 @@ class TestXY:
         assert sample_xy.axis_info["d3"][1] == "polar"
         assert isinstance(sample_xy.params["detector_voltage"], float)
         assert isinstance(sample_xy.params["values_curve"], int)
+        assert isinstance(sample_xy.params["eff_workfunction"], float)
+        assert isinstance(sample_xy.params["excitation_energy"], float)
         np.testing.assert_allclose(sample_xy.params["eff_workfunction"], 4.32)
         np.testing.assert_allclose(sample_xy.params["excitation_energy"], 21.2182)
         np.testing.assert_allclose(sample_xy.axis_info["d1"][0][5], 19.782284)

--- a/tests/test_prodigy_xy.py
+++ b/tests/test_prodigy_xy.py
@@ -12,7 +12,14 @@ data_dir = Path(__file__).parent.parent / "src" / "arpes" / "example_data"
 
 @pytest.fixture
 def sample_xy() -> ProdigyXY:
-    """Fixture."""
+    """Fixture that reads data from a .xy file and returns a ProdigyXY object.
+
+    Reads the contents of the "BLGr_GK_map.xy" file located in the data directory,
+    and initializes a ProdigyXY object with the read data.
+
+    Returns:
+        ProdigyXY: An instance of ProdigyXY initialized with the data from the .xy file.
+    """
     with Path(data_dir / "BLGr_GK_map.xy").open(mode="r") as xy_file:
         xy_data: list[str] = xy_file.readlines()
     return ProdigyXY(xy_data)
@@ -22,7 +29,17 @@ class TestXY:
     """test Class for prodigy_xy.py."""
 
     def test_parameters(self, sample_xy: ProdigyXY) -> None:
-        """Test for reading xy file."""
+        """Test for reading xy file.
+
+        This test verifies the following properties of the `sample_xy` object:
+        - The axis information for dimensions d1, d2, and d3.
+        - The types of various parameters in the `params` dictionary.
+        - The values of specific parameters and axis information using `np.testing.assert_allclose`.
+
+        Args:
+            sample_xy (ProdigyXY): The sample object to be tested.
+
+        """
         assert sample_xy.axis_info["d1"][1] == "eV"
         assert sample_xy.axis_info["d2"][1] == "nonenergy"
         assert sample_xy.axis_info["d3"][1] == "polar"
@@ -36,11 +53,27 @@ class TestXY:
         np.testing.assert_allclose(sample_xy.axis_info["d3"][0][0], -68.0)
 
     def test_integrated_intensity(self, sample_xy: ProdigyXY) -> None:
-        """Test for integrated_intensity property."""
+        """Test the `integrated_intensity` property of the `ProdigyXY` class.
+
+        This test verifies that the `integrated_intensity` property of the
+        `sample_xy` instance of `ProdigyXY` returns the expected value.
+
+        Parameters:
+        sample_xy (ProdigyXY): An instance of the `ProdigyXY` class to be tested.
+
+        """
         np.testing.assert_allclose(sample_xy.integrated_intensity, 1.01248214e+08)
 
     def test_convert_to_data_array(self, sample_xy: ProdigyXY) -> None:
-        """Test for convert to xr.DataArray."""
+        """Test the conversion of ProdigyXY object to an xarray.DataArray.
+
+        This test verifies that the resulting DataArray has the correct dimensions,
+        shape, and coordinate values.
+
+        Args:
+            sample_xy (ProdigyXY): An instance of ProdigyXY to be converted.
+
+        """
         sample_data_array = sample_xy.to_data_array()
         assert sample_data_array.dims == ("eV", "nonenergy", "polar")
         assert sample_data_array.shape == (137, 82, 116)


### PR DESCRIPTION
In this PR, I am including a new dataset "DSNP_UMCS_map.xy" used in tests to verify the proper functioning of 3D map loading for the DSNP_UMCS plugin.

The test is included in test_basic_data_loading.py as "dsnp_umcs_load_map".

Additionally, in the test of the related prodigy_xy plugin, I have added a type assertions for eff_workfunction and excitation_energy before their values are tested.

Finally, the docstrings in test_prodigy_xy have been updated (with one line added DSNP_UMCS docstrings as well).