### PR TITLE
Fix Phelix plugin

### DIFF
--- a/src/arpes/endstations/plugin/Phelix.py
+++ b/src/arpes/endstations/plugin/Phelix.py
@@ -106,6 +106,8 @@ class Phelix(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstatio
                 dispersion_mode = self._LENS_MAPPING[lens_mode]
                 if dispersion_mode:
                     data = data.rename({"nonenergy": "phi"})
+                    # Convert phi to radians
+                    data = data.assign_coords(phi=np.deg2rad(data.phi))
                 else:
                     data = data.rename({"nonenergy": "x"})
             else:
@@ -114,14 +116,23 @@ class Phelix(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstatio
 
             if "anr1" in data.coords:
                 # Invert the anr1 manipulator axis and shift it to get theta angle
-                data = data.assign_coords(
-                    theta = np.deg2rad(-data.anr1 - Phelix.NORMAL_EMISSION["anr1"]))
+                anr1 = -data.anr1 - Phelix.NORMAL_EMISSION["anr1"]
+                data = data.assign_coords(anr1=anr1)
+                # Rename anr1 coordinate to theta
+                data = data.rename({"anr1": "theta"})
+                # Invert the theta axis
                 data = data.isel(theta=slice(None, None, -1))
+                # Convert theta to radians
+                data = data.assign_coords(
+                    theta = np.deg2rad(data.theta))
+
 
             if "shiftx" in data.coords:
-                # Convert shiftx parameter to psi angle in rad
+                # Rename shiftx coordinate to psi
+                data = data.rename({"shiftx": "psi"})
+                # Convert psi to radians
                 data = data.assign_coords(
-                    psi = np.deg2rad(data.shiftx))
+                    psi = np.deg2rad(data.psi))
 
             return xr.Dataset({"spectrum": data}, attrs=data.attrs)
 

--- a/src/arpes/endstations/plugin/Phelix.py
+++ b/src/arpes/endstations/plugin/Phelix.py
@@ -28,10 +28,12 @@ if TYPE_CHECKING:
     from arpes._typing import Spectrometer
     from arpes.endstations import ScanDesc
 
-__all__ = ["Phelix"]
+__all__ = ["PhelixEndstation"]
 
 
-class Phelix(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstation):
+class PhelixEndstation(HemisphericalEndstation,
+            SingleFileEndstation,
+            SynchrotronEndstation):
     """Implements loading xy text files from the Specs Prodigy software."""
 
     PRINCIPAL_NAME = "Phelix"
@@ -116,7 +118,7 @@ class Phelix(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstatio
 
             if "anr1" in data.coords:
                 # Invert the anr1 manipulator axis and shift it to get theta angle
-                anr1 = -data.anr1 - Phelix.NORMAL_EMISSION["anr1"]
+                anr1 = -data.anr1 - PhelixEndstation.NORMAL_EMISSION["anr1"]
                 data = data.assign_coords(anr1=anr1)
                 # Rename anr1 coordinate to theta
                 data = data.rename({"anr1": "theta"})
@@ -182,4 +184,4 @@ class Phelix(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstatio
         return super().postprocess_final(data, scan_desc)
 
 
-add_endstation(Phelix)
+add_endstation(PhelixEndstation)

--- a/src/arpes/endstations/plugin/Uranos.py
+++ b/src/arpes/endstations/plugin/Uranos.py
@@ -35,10 +35,10 @@ if TYPE_CHECKING:
     from arpes._typing import Spectrometer
     from arpes.endstations import ScanDesc
 
-__all__ = ["Uranos"]
+__all__ = ["UranosEndstation"]
 
 
-class Uranos(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstation):
+class UranosEndstation(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstation):
     """Class for Uranos beamline at Solaris Krakow, PL."""
 
     PRINCIPAL_NAME = "Uranos"
@@ -148,7 +148,7 @@ class Uranos(HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstatio
         # Convert to binding energy notation
         binding_energies = (data.coords["eV"].values
                             - data.attrs["hv"]
-                            + Uranos._ANALYZER_WORK_FUNCTION)
+                            + UranosEndstation._ANALYZER_WORK_FUNCTION)
         data = data.assign_coords({"eV": binding_energies})
 
         return super().postprocess_final(data, scan_desc)
@@ -261,11 +261,13 @@ def _fix_angles(data: xr.DataArray) -> xr.DataArray:
     """
     # Shift manipulator r1 to get theta angle and convert to radians
     if "r1" in data.attrs:
-        data = data.assign_coords({"theta": np.deg2rad(data.r1 - Uranos.NORMAL_EMISSION["r1"])})
+        data = data.assign_coords({"theta":
+                                   np.deg2rad(data.r1 - UranosEndstation.NORMAL_EMISSION["r1"])})
 
     # Shift manipulator r3 to get beta angle and convert to radians
     if "r3" in data.attrs:
-        data = data.assign_coords({"beta": np.deg2rad(data.r3 - Uranos.NORMAL_EMISSION["r3"])})
+        data = data.assign_coords({"beta":
+                                   np.deg2rad(data.r3 - UranosEndstation.NORMAL_EMISSION["r3"])})
 
     # Convert phi to radians
     if "phi" in data.coords:
@@ -286,4 +288,4 @@ def _formatted_value(value: str) -> float | str:
         return value
 
 
-add_endstation(Uranos)
+add_endstation(UranosEndstation)


### PR DESCRIPTION
This pull request addresses the following updates: 

1. Fix Phelix plugin:
- fixed the problem with phi, theta and psi coordinates (first shift if necessary, then rename and finally convert to rad)
- added location to attributes,
- added provenance_from_file,
- improved docstrings.

2. Refractor Phelix plugin name to PhelixEndstation (together with Uranos plugin) for consistency with other enstations plugins.