### PR TITLE
Improve Tests and Documentation for Example Data Loading

### DIFF
--- a/tests/test_direct_and_example_data_loading.py
+++ b/tests/test_direct_and_example_data_loading.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import pytest
@@ -50,14 +51,18 @@ def test_load_data_with_plugin_specified() -> None:
     assert np.all(data.spectrum.values == directly_specified_data.spectrum.values)
 
 
-@pytest.mark.parametrize("data_name, expected_shape", [
+@pytest.mark.parametrize(("data_name", "expected_shape"), [
     ("cut", (240, 240)),
     ("cut2", (600, 501)),
     ("map", (81, 150, 111)),
     ("map2", (137, 82, 116))],
     ids=["cut", "cut2", "map", "map2"])
 
-def test_load_example_data(data_name, expected_shape) -> None:
+
+def test_load_example_data(
+    data_name: Literal["cut", "cut2", "map", "map2"],
+    expected_shape: tuple[int, int] | tuple[int, int, int],
+    ) -> None:
     """Test loading example data for different types."""
     data = load_example_data(data_name)
 

--- a/tests/test_direct_and_example_data_loading.py
+++ b/tests/test_direct_and_example_data_loading.py
@@ -67,11 +67,15 @@ def test_load_data_with_plugin_specified() -> None:
     # Description: Parametrize test cases for different example data and their expected shapes
 )
 
-def test_load_example_data(
+def test_load_example_map_data(
     data_name: Literal["cut", "cut2", "cut3", "map", "map2"],
     expected_shape: tuple[int, int] | tuple[int, int, int],
     ) -> None:
-    """Test loading example data.
+    """Test loading example ARPES map data.
+
+    This test validates the loading of example data in a form of:
+        - 2D cuts: Two-dimensional data slices.
+        - 3D maps: Three-dimensional datasets.
 
     Parameters:
     data_name (Literal["cut", "cut2", "cut3, "map", "map2"]): The name of the example data to load.

--- a/tests/test_direct_and_example_data_loading.py
+++ b/tests/test_direct_and_example_data_loading.py
@@ -90,10 +90,13 @@ def test_load_example_data(
     assert isinstance(data, xr.Dataset)
     assert isinstance(data.spectrum, xr.DataArray)
 
-    # check that the data has the expected shape
-    assert data.spectrum.shape == expected_shape
+    # Verify the shape of 'spectrum' matches the expected shape
+    assert data.spectrum.shape == expected_shape, (
+        f"{data_name}: Shape mismatch. "
+        f"Expected {expected_shape}, got {data.spectrum.shape}"
+    )
 
-    # assert that all necessary coordinates are present
+    # Verify all necessary coordinates are present
     necessary_coords = {"phi", "psi", "alpha", "chi", "beta", "theta", "x", "y", "z", "hv"}
-    for necessary_coord in necessary_coords:
-        assert necessary_coord in data.coords
+    missing_coords = necessary_coords - set(map(str, data.coords))
+    assert not missing_coords, f"{data_name}: Missing coordinates: {missing_coords}"

--- a/tests/test_direct_and_example_data_loading.py
+++ b/tests/test_direct_and_example_data_loading.py
@@ -59,21 +59,22 @@ def test_load_data_with_plugin_specified() -> None:
     [
         ("cut", (240, 240)),
         ("cut2", (600, 501)),
+        ("cut3", (137, 82)),
         ("map", (81, 150, 111)),
         ("map2", (137, 82, 116)),
     ],
-    ids=["cut", "cut2", "map", "map2"],
+    ids=["cut", "cut2", "cut3", "map", "map2"],
     # Description: Parametrize test cases for different example data and their expected shapes
 )
 
 def test_load_example_data(
-    data_name: Literal["cut", "cut2", "map", "map2"],
+    data_name: Literal["cut", "cut2", "cut3", "map", "map2"],
     expected_shape: tuple[int, int] | tuple[int, int, int],
     ) -> None:
     """Test loading example data.
 
     Parameters:
-    data_name (Literal["cut", "cut2", "map", "map2"]): The name of the example data to load.
+    data_name (Literal["cut", "cut2", "cut3, "map", "map2"]): The name of the example data to load.
     expected_shape (tuple[int, int] | tuple[int, int, int]): The expected shape of the data.
 
     Asserts:

--- a/tests/test_direct_and_example_data_loading.py
+++ b/tests/test_direct_and_example_data_loading.py
@@ -14,9 +14,12 @@ from arpes.io import load_data, load_example_data
 
 
 def test_load_data() -> None:
-    """[TODO:summary].
+    """Test direct loading of fits data using ALG-MC.
 
-    [TODO:description]
+    This test function loads data from a specified FITS file located in the
+    'resources/datasets/basic' directory and checks if the loaded data is an
+    instance of an xarray.Dataset. It also verifies that the shape of the
+    spectrum data is (240, 240).
 
     Args:
         sandbox_configuration ([TODO:type]): [TODO:description]
@@ -51,19 +54,36 @@ def test_load_data_with_plugin_specified() -> None:
     assert np.all(data.spectrum.values == directly_specified_data.spectrum.values)
 
 
-@pytest.mark.parametrize(("data_name", "expected_shape"), [
-    ("cut", (240, 240)),
-    ("cut2", (600, 501)),
-    ("map", (81, 150, 111)),
-    ("map2", (137, 82, 116))],
-    ids=["cut", "cut2", "map", "map2"])
-
+@pytest.mark.parametrize(
+    ("data_name", "expected_shape"),
+    [
+        ("cut", (240, 240)),
+        ("cut2", (600, 501)),
+        ("map", (81, 150, 111)),
+        ("map2", (137, 82, 116)),
+    ],
+    ids=["cut", "cut2", "map", "map2"],
+    # Description: Parametrize test cases for different example data and their expected shapes
+)
 
 def test_load_example_data(
     data_name: Literal["cut", "cut2", "map", "map2"],
     expected_shape: tuple[int, int] | tuple[int, int, int],
     ) -> None:
-    """Test loading example data for different types."""
+    """Test loading example data.
+
+    Parameters:
+    data_name (Literal["cut", "cut2", "map", "map2"]): The name of the example data to load.
+    expected_shape (tuple[int, int] | tuple[int, int, int]): The expected shape of the data.
+
+    Asserts:
+    - The loaded data is an xarray Dataset.
+    - The 'spectrum' in the dataset is an xarray DataArray.
+    - The shape of the 'spectrum' matches the expected shape.
+    - All necessary coordinates:
+        ('phi', 'psi', 'alpha', 'chi', 'beta', 'theta', 'x', 'y', 'z', 'hv')
+        are present in the data.
+    """
     data = load_example_data(data_name)
 
     # check that the data is an xarray dataset

--- a/tests/test_direct_and_example_data_loading.py
+++ b/tests/test_direct_and_example_data_loading.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from arpes.endstations.plugin.ALG_main import ALGMainChamber
@@ -49,15 +50,25 @@ def test_load_data_with_plugin_specified() -> None:
     assert np.all(data.spectrum.values == directly_specified_data.spectrum.values)
 
 
-def test_load_example_data() -> None:
-    """[TODO:summary].
+@pytest.mark.parametrize("data_name, expected_shape", [
+    ("cut", (240, 240)),
+    ("cut2", (600, 501)),
+    ("map", (81, 150, 111)),
+    ("map2", (137, 82, 116))],
+    ids=["cut", "cut2", "map", "map2"])
 
-    [TODO:description]
+def test_load_example_data(data_name, expected_shape) -> None:
+    """Test loading example data for different types."""
+    data = load_example_data(data_name)
 
-    Args:
-        sandbox_configuration ([TODO:type]): [TODO:description]
-    """
-    data = load_example_data("cut")
-
+    # check that the data is an xarray dataset
     assert isinstance(data, xr.Dataset)
-    assert data.spectrum.shape == (240, 240)
+    assert isinstance(data.spectrum, xr.DataArray)
+
+    # check that the data has the expected shape
+    assert data.spectrum.shape == expected_shape
+
+    # assert that all necessary coordinates are present
+    necessary_coords = {"phi", "psi", "alpha", "chi", "beta", "theta", "x", "y", "z", "hv"}
+    for necessary_coord in necessary_coords:
+        assert necessary_coord in data.coords


### PR DESCRIPTION
**Summary of changes:**

- Added test cases for all cut and map example data.
- Added type hints and updated docstrings.
- Renamed test_load_example_data to test_load_example_map_data.
- Added assertion messages.