### PR TITLE
Refactor: replace public-facing asserts with explicit exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 uv.lock
+*.bak

--- a/src/arpes/analysis/align.py
+++ b/src/arpes/analysis/align.py
@@ -107,7 +107,8 @@ def align(
     if len(a.dims) == 1:
         return align1d(a, b, **kwargs)
 
-    assert len(a.dims) == TWO_DIMENSION
+    if not (len(a.dims) == TWO_DIMENSION):
+        raise ValueError('Assertion failed: len(a.dims) == TWO_DIMENSION')
     return align2d(a, b, **kwargs)
 
 

--- a/src/arpes/analysis/background.py
+++ b/src/arpes/analysis/background.py
@@ -24,8 +24,10 @@ def calculate_background_hull(
     breakpoints: list[float | None] | None = None,
 ) -> xr.DataArray:
     """Calculates background using the convex hull of the data (intensity as a Z axis)."""
-    assert isinstance(arr, xr.DataArray)
-    assert len(arr.dims) == 1
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
+    if not (len(arr.dims) == 1):
+        raise ValueError('Assertion failed: len(arr.dims) == 1')
     if breakpoints:
         breakpoints = [None, *breakpoints, None]
         dim = arr.dims[0]

--- a/src/arpes/analysis/band_analysis.py
+++ b/src/arpes/analysis/band_analysis.py
@@ -86,7 +86,8 @@ def fit_for_effective_mass(
     fit_results = data.S.modelfit(coords="eV", model=model, **fit_kwargs)
     if mom_dim in {"phi", "beta", "theta"}:
         forward = convert_coordinates_to_kspace_forward(data)
-        assert isinstance(forward, xr.Dataset)
+        if not isinstance(forward, xr.Dataset):
+            raise TypeError('Expected forward to be instance of xr.Dataset')
         final_mom = next(dim for dim in ["kx", "ky", "kp", "kz"] if dim in forward)
         eVs = fit_results.results.F.p("a_center").values
         kps = [
@@ -414,7 +415,8 @@ def fit_patterned_bands(  # noqa: PLR0913
         # initial value for the amplitude from the approximate peak location
         params = params or {}
         dims = dims or ()
-        assert band is not None
+        if not (band is not None):
+            raise ValueError('Assertion failed: band is not None')
         coord_name = next(d for d in dims if d in coord_dict)
         partial_band_locations = list(
             _interpolate_intersecting_fragments(
@@ -540,7 +542,8 @@ def fit_bands(
     Todo:
         Deep refactoring. The current version may not work.
     """
-    assert direction in {"edc", "mdc", "EDC", "MDC"}
+    if not (direction in {"edc", "mdc", "EDC", "MDC"}):
+        raise ValueError('Assertion failed: direction in {"edc", "mdc", "EDC", "MDC"}')
 
     directions, broadcast_direction = list(arr.dims), "eV"
 
@@ -630,7 +633,8 @@ def _interpolate_intersecting_fragments(
         coord_index ([TODO:type]): [TODO:description]
         points ([TODO:type]): [TODO:description]
     """
-    assert len(points[0]) == TWO_DIMENSION
+    if not (len(points[0]) == TWO_DIMENSION):
+        raise ValueError('Assertion failed: len(points[0]) == TWO_DIMENSION')
 
     for point_low, point_high in pairwise(points):
         coord_other_index = 1 - coord_index

--- a/src/arpes/analysis/deconvolution.py
+++ b/src/arpes/analysis/deconvolution.py
@@ -154,7 +154,8 @@ def make_psf(
     """
     strides = data.G.stride(generic_dim_names=False)
     logger.debug(f"strides: {strides}")
-    assert set(strides) == set(sigmas)
+    if not (set(strides) == set(sigmas)):
+        raise ValueError('Assertion failed: set(strides) == set(sigmas)')
     pixels: dict[Hashable, int] = dict(
         zip(
             data.dims,

--- a/src/arpes/analysis/derivative.py
+++ b/src/arpes/analysis/derivative.py
@@ -69,8 +69,10 @@ def _vector_diff(
 
     slice1: list[slice] | tuple[slice, ...] = [slice(None)] * arr.ndim
     slice2: list[slice] | tuple[slice, ...] = [slice(None)] * arr.ndim
-    assert isinstance(slice1, list)
-    assert isinstance(slice2, list)
+    if not isinstance(slice1, list):
+        raise TypeError('Expected slice1 to be instance of list')
+    if not isinstance(slice2, list):
+        raise TypeError('Expected slice2 to be instance of list')
     for dim, delta_val in enumerate(delta):
         if delta_val != 0:
             if delta_val < 0:
@@ -81,8 +83,10 @@ def _vector_diff(
                 slice2[dim] = slice(None, -delta_val)
 
     slice1, slice2 = tuple(slice1), tuple(slice2)
-    assert isinstance(slice1, tuple)
-    assert isinstance(slice2, tuple)
+    if not isinstance(slice1, tuple):
+        raise TypeError('Expected slice1 to be instance of tuple')
+    if not isinstance(slice2, tuple):
+        raise TypeError('Expected slice2 to be instance of tuple')
     return (
         _vector_diff(arr[slice1] - arr[slice2], delta, n - 1)
         if n > 1
@@ -115,7 +119,8 @@ def minimum_gradient(
         The gradient of the original intensity, which enhances the peak position.
     """
     arr = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     smooth_ = _nothing_to_array if smooth_fn is None else smooth_fn
     arr = smooth_(arr)
     arr = arr.assign_attrs(data.attrs)
@@ -137,7 +142,8 @@ def _gradient_modulus(
     Returns: xr.DataArray
     """
     spectrum = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(spectrum, xr.DataArray)
+    if not isinstance(spectrum, xr.DataArray):
+        raise TypeError('Expected spectrum to be instance of xr.DataArray')
     values: NDArray[np.floating] = spectrum.values
     gradient_vector = np.zeros(shape=(8, *values.shape))
 
@@ -174,8 +180,10 @@ def curvature1d(
     Returns:
         The curvature of the intensity of the original data.
     """
-    assert isinstance(arr, xr.DataArray)
-    assert alpha > 0
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
+    if not (alpha > 0):
+        raise ValueError('Assertion failed: alpha > 0')
     dim = dim or str(arr.dims[0])
     smooth_ = _nothing_to_array if smooth_fn is None else smooth_fn
     arr = smooth_(arr)
@@ -228,9 +236,12 @@ def curvature2d(
 
     It should essentially same as the ``curvature`` function, but the ``weight`` argument is added.
     """
-    assert isinstance(arr, xr.DataArray)
-    assert alpha > 0
-    assert weight2d != 0
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
+    if not (alpha > 0):
+        raise ValueError('Assertion failed: alpha > 0')
+    if not (weight2d != 0):
+        raise ValueError('Assertion failed: weight2d != 0')
     dx, dy = tuple(float(arr.coords[str(d)][1] - arr.coords[str(d)][0]) for d in arr.dims[:2])
     weight = (dx / dy) ** 2
     arr = smooth_fn(arr) if smooth_fn is not None else arr
@@ -300,7 +311,8 @@ def dn_along_axis(
     Returns:
         The nth derivative data.
     """
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     dim = dim or str(arr.dims[0])
     smooth_ = _nothing_to_array if smooth_fn is None else smooth_fn
     dn_arr = smooth_(arr)

--- a/src/arpes/analysis/filters.py
+++ b/src/arpes/analysis/filters.py
@@ -102,7 +102,8 @@ def boxcar_filter_arr(
     Returns:
         smoothed data.
     """
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     if size is None:
         size = {}
 
@@ -173,9 +174,8 @@ def savitzky_golay_filter(  # noqa: PLR0913
     axis = data.dims.index(dim) if dim else -1
     dim = dim or data.dims[0]
     coords_diffs = np.diff(data.coords[dim])
-    assert np.allclose(coords_diffs, coords_diffs[0], rtol=1e-5, atol=1e-6), (
-        f"The coordinates must be equally spaced. Consider to use interpolation. f{coords_diffs}"
-    )
+    if not (np.allclose(coords_diffs, coords_diffs[0], rtol=1e-5, atol=1e-6)):
+        raise ValueError('Assertion failed: np.allclose(coords_diffs, coords_diffs[0], rtol=1e-5, atol=1e-6)')
     return data.G.with_values(
         savgol_filter(
             data,

--- a/src/arpes/analysis/forward_conversion.py
+++ b/src/arpes/analysis/forward_conversion.py
@@ -99,7 +99,8 @@ def convert_coordinate_forward(
         The location of the desired coordinate in **momentum**.
     """
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert data.spectrum_type in {"cut", "map"}, 'spectrum type must be "cut" or "map"'
+    if not (data.spectrum_type in {"cut", "map"}):
+        raise ValueError('spectrum type must be "cut" or "map"')
     if data.spectrum_type == "map":
         if "eV" in coords:  # TODO: correction is required for "cut" data
             coords = dict(coords)
@@ -195,7 +196,8 @@ def convert_through_angular_pair(  # noqa: PLR0913
     Returns:
         The momentum cut passing first through `first_point` and then through `second_point`.
     """
-    assert data.S.spectrum_type is SpectrumType.MAP
+    if not (data.S.spectrum_type is SpectrumType.MAP):
+        raise ValueError('Assertion failed: data.S.spectrum_type is SpectrumType.MAP')
     k_first_point = convert_coordinate_forward(data, first_point, **k_coords)
     k_second_point = convert_coordinate_forward(data, second_point, **k_coords)
 
@@ -204,9 +206,12 @@ def convert_through_angular_pair(  # noqa: PLR0913
         msg = f"Two point {k_dims} momentum conversion is not supported yet."
         raise NotImplementedError(msg)
 
-    assert k_dims == set(cut_specification.keys()).union(transverse_specification.keys())
-    assert "ky" in transverse_specification  # You must use ky as the transverse coordinate for now
-    assert len(cut_specification) == 1
+    if not (k_dims == set(cut_specification.keys()).union(transverse_specification.keys())):
+        raise ValueError('Assertion failed: k_dims == set(cut_specification.keys()).union(transverse_specification.keys())')
+    if not ("ky" in transverse_specification):
+        raise ValueError('Assertion failed: "ky" in transverse_specification')
+    if not (len(cut_specification) == 1):
+        raise ValueError('Assertion failed: len(cut_specification) == 1')
 
     offset_ang = np.arctan2(
         k_second_point["ky"] - k_first_point["ky"],
@@ -296,7 +301,8 @@ def convert_through_angular_point(
         **k_coords,
     )
     all_momentum_dims = set(location_in_kspace.keys())
-    assert all_momentum_dims == set(cut_specification.keys()).union(transverse_specification.keys())
+    if not (all_momentum_dims == set(cut_specification.keys()).union(transverse_specification.keys())):
+        raise ValueError('Assertion failed: all_momentum_dims == set(cut_specification.keys()).union(transverse_specification.keys())')
 
     # adjust output coordinate ranges
     transverse_specification = {
@@ -361,9 +367,11 @@ def convert_coordinates(
     ) -> NDArray[np.floating] | float:
         if isinstance(c, float):
             return c
-        assert isinstance(c, np.ndarray)
+        if not isinstance(c, np.ndarray):
+            raise TypeError('Expected c to be instance of np.ndarray')
         index_list: list[slice | None] = [np.newaxis] * len(old_dims)
-        assert old_dims.index(cname) is not None
+        if not (old_dims.index(cname) is not None):
+            raise ValueError('Assertion failed: old_dims.index(cname) is not None')
         index_list[old_dims.index(cname)] = slice(None, None)
         return c[tuple(index_list)]
 
@@ -559,7 +567,8 @@ def _broadcast_by_dim_location(
         return np.ones(target_shape) * data
     # else we are dealing with an actual array
     the_slice: list[slice | None] = [None] * len(target_shape)
-    assert dim_location is not None
+    if not (dim_location is not None):
+        raise ValueError('Assertion failed: dim_location is not None')
     the_slice[dim_location] = slice(None, None, None)
     the_slice = [np.newaxis if s is None else s for s in the_slice]
     return np.asarray(data)[tuple(the_slice)]

--- a/src/arpes/analysis/gap.py
+++ b/src/arpes/analysis/gap.py
@@ -149,7 +149,8 @@ def normalize_by_fermi_dirac(  # noqa: PLR0913
     # <== NEED TO CHECK (What it the type of without_background ?)
 
     without_background_arr = normalize_to_spectrum(without_background)
-    assert isinstance(without_background_arr, xr.DataArray)
+    if not isinstance(without_background_arr, xr.DataArray):
+        raise TypeError('Expected without_background_arr to be instance of xr.DataArray')
     if temperature_axis:
         divided = without_background_arr.G.map_axes(
             temperature_axis,
@@ -193,7 +194,8 @@ def _shift_energy_interpolate(
         closest_to_zero = data_arr.coords["eV"].sel(eV=0, method="nearest")
         shift = -closest_to_zero
 
-    assert isinstance(shift, xr.DataArray)
+    if not isinstance(shift, xr.DataArray):
+        raise TypeError('Expected shift to be instance of xr.DataArray')
     stride = data_arr.G.stride("eV", generic_dim_names=False)
 
     if np.abs(shift) >= stride:
@@ -203,7 +205,8 @@ def _shift_energy_interpolate(
         shift = shift - stride * n_strides
 
     new_axis = new_axis + shift
-    assert shift is not None
+    if not (shift is not None):
+        raise ValueError('Assertion failed: shift is not None')
 
     weight = float(shift / stride)
     new_values = new_values + data_arr.values * (1 - weight)
@@ -241,7 +244,8 @@ def symmetrize(
 
     if subpixel:
         data = _shift_energy_interpolate(data)
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
 
     above = data.sel(eV=slice(0, None))
     below = data.sel(eV=slice(None, 0)).copy(deep=True)

--- a/src/arpes/analysis/general.py
+++ b/src/arpes/analysis/general.py
@@ -47,7 +47,8 @@ def fit_fermi_edge(
     Returns:
         The Fermi edge location.
     """
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     if energy_range is None:
         energy_range = slice(-0.1, 0.1)
 
@@ -101,7 +102,8 @@ def normalize_by_fermi_distribution(
             center=rigid_shift,
             width=K_BOLTZMANN_EV_KELVIN * data.S.temp,
         )
-    assert isinstance(distrib, np.ndarray)
+    if not isinstance(distrib, np.ndarray):
+        raise TypeError('Expected distrib to be instance of np.ndarray')
     # don't boost by more than 90th percentile of input, by default
     max_gain = (
         max_gain or min(
@@ -228,7 +230,8 @@ def rebin(
         shape = {}
         for k, v in bin_width.items():
             shape[k] = len(data.coords[k]) // v
-    assert bool(shape), "Set shape/bin_width"
+    if not (bool(shape)):
+        raise ValueError('Set shape/bin_width')
     for bin_axis, bins in shape.items():
         data = _bin(data, bin_axis, bins, method)
     return data

--- a/src/arpes/analysis/kfermi.py
+++ b/src/arpes/analysis/kfermi.py
@@ -33,7 +33,8 @@ def kfermi_from_mdcs(mdc_results: XrTypes, param: str = "") -> NDArray[np.float6
     """
     real_param_name: set[str] | str = set()
     mdc_results = mdc_results if isinstance(mdc_results, xr.DataArray) else mdc_results.results
-    assert isinstance(mdc_results, xr.DataArray)
+    if not isinstance(mdc_results, xr.DataArray):
+        raise TypeError('Expected mdc_results to be instance of xr.DataArray')
     param_names = mdc_results.F.parameter_names
 
     if param in param_names and param is not None:
@@ -43,7 +44,8 @@ def kfermi_from_mdcs(mdc_results: XrTypes, param: str = "") -> NDArray[np.float6
         if not param:
             best_names = [p for p in best_names if param in p]
 
-        assert len(best_names) == 1
+        if not (len(best_names) == 1):
+            raise ValueError('Assertion failed: len(best_names) == 1')
         real_param_name = best_names[0]
 
     def nan_sieve(_: xr.DataArray, x: xr.DataArray) -> bool:

--- a/src/arpes/analysis/mask.py
+++ b/src/arpes/analysis/mask.py
@@ -95,7 +95,8 @@ def polys_to_mask(
         grid = grid.reshape(list(shape)[::-1]).T
 
         mask = grid if mask is None else np.logical_or(mask, grid)
-    assert isinstance(mask, np.ndarray)
+    if not isinstance(mask, np.ndarray):
+        raise TypeError('Expected mask to be instance of np.ndarray')
 
     if invert:
         mask = np.logical_not(mask)
@@ -179,7 +180,8 @@ def apply_mask(
     if isinstance(mask, dict):
         fermi = mask.get("fermi", None)
         dims: tuple[str, ...] = mask.get("dims", data.dims)
-        assert isinstance(mask, dict)
+        if not isinstance(mask, dict):
+            raise TypeError('Expected mask to be instance of dict')
         mask_arr: NDArray[np.bool_] = polys_to_mask(
             mask_dict=mask,
             coords=data.coords,

--- a/src/arpes/analysis/path.py
+++ b/src/arpes/analysis/path.py
@@ -61,13 +61,15 @@ def discretize_path(
     elif isinstance(scaling, xr.Dataset):
         scaling = {str(k): scaling[k].item() for k in scaling.data_vars}
     else:
-        assert isinstance(scaling, dict)
+        if not isinstance(scaling, dict):
+            raise TypeError('Expected scaling to be instance of dict')
 
     order = list(path.data_vars)
     if isinstance(scaling, dict):
         scaling = np.array(float(scaling[d]) for d in order)
 
-    assert isinstance(scaling, np.ndarray | float)
+    if not isinstance(scaling, np.ndarray | float):
+        raise TypeError('Expected scaling to be instance of np.ndarray | float')
 
     def as_vec(ds: xr.Dataset) -> NDArray[np.float64]:
         return np.array([ds[k].item() for k in order])
@@ -290,7 +292,8 @@ def slice_along_path(  # noqa: PLR0913
         },
         as_dataset=True,
     )
-    assert isinstance(converted_ds, xr.Dataset)
+    if not isinstance(converted_ds, xr.Dataset):
+        raise TypeError('Expected converted_ds to be instance of xr.Dataset')
 
     if (
         axis_name in arr.dims and len(parsed_interpolation_points) == TWO_DIMENSION

--- a/src/arpes/analysis/pocket.py
+++ b/src/arpes/analysis/pocket.py
@@ -118,7 +118,8 @@ def radial_edcs_along_pocket(
     data_array = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
     fermi_surface_dims = list(data_array.dims)
 
-    assert "eV" in fermi_surface_dims
+    if not ("eV" in fermi_surface_dims):
+        raise ValueError('Assertion failed: "eV" in fermi_surface_dims')
     fermi_surface_dims.remove("eV")
 
     center_point: dict[Hashable, float] = {k: v for k, v in kwargs.items() if k in data_array.dims}
@@ -187,7 +188,8 @@ def curves_along_pocket(
         the coordinates of each slice around the pocket center.
     """
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     fermi_surface_dims = list(data.dims)
     if "eV" in fermi_surface_dims:
         fermi_surface_dims.remove("eV")
@@ -263,7 +265,8 @@ def find_kf_by_mdc(
         slice_data if isinstance(slice_data, xr.DataArray) else normalize_to_spectrum(slice_data)
     )
 
-    assert isinstance(slice_data, xr.DataArray)
+    if not isinstance(slice_data, xr.DataArray):
+        raise TypeError('Expected slice_data to be instance of xr.DataArray')
     if "eV" in slice_data.dims:
         slice_arr = slice_data.sum("eV")
 

--- a/src/arpes/analysis/sarpes.py
+++ b/src/arpes/analysis/sarpes.py
@@ -23,11 +23,16 @@ def normalize_sarpes_photocurrent(data: xr.Dataset) -> xr.Dataset:
     Returns:
         Scaled data. Independently, photocurrent up and down channels are used to perform scaling.
     """
-    assert isinstance(data, xr.Dataset)
-    assert "down" in data.data_vars
-    assert "up" in data.data_vars
-    assert "photocurrent_up" in data.data_vars
-    assert "photocurrent_down" in data.data_vars
+    if not isinstance(data, xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.Dataset')
+    if not ("down" in data.data_vars):
+        raise ValueError('Assertion failed: "down" in data.data_vars')
+    if not ("up" in data.data_vars):
+        raise ValueError('Assertion failed: "up" in data.data_vars')
+    if not ("photocurrent_up" in data.data_vars):
+        raise ValueError('Assertion failed: "photocurrent_up" in data.data_vars')
+    if not ("photocurrent_down" in data.data_vars):
+        raise ValueError('Assertion failed: "photocurrent_down" in data.data_vars')
 
     copied = data.copy(deep=True)
     copied.down.values = (copied.down * (copied.photocurrent_up / copied.photocurrent_down)).values
@@ -50,9 +55,12 @@ def to_up_down(data: xr.Dataset) -> xr.Dataset:
     Returns:
         The data after conversion to up-down representation.
     """
-    assert isinstance(data, xr.Dataset)
-    assert "intensity" in data.data_vars
-    assert "polarization" in data.data_vars
+    if not isinstance(data, xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.Dataset')
+    if not ("intensity" in data.data_vars):
+        raise ValueError('Assertion failed: "intensity" in data.data_vars')
+    if not ("polarization" in data.data_vars):
+        raise ValueError('Assertion failed: "polarization" in data.data_vars')
 
     return xr.Dataset(
         data_vars={
@@ -81,10 +89,13 @@ def to_intensity_polarization(
     Returns:
         The data after conversion to intensity-polarization representation.
     """
-    assert isinstance(data, xr.Dataset)
+    if not isinstance(data, xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.Dataset')
 
-    assert "up" in data.data_vars
-    assert "down" in data.data_vars
+    if not ("up" in data.data_vars):
+        raise ValueError('Assertion failed: "up" in data.data_vars')
+    if not ("down" in data.data_vars):
+        raise ValueError('Assertion failed: "down" in data.data_vars')
 
     intensity = data.up + data.down
 

--- a/src/arpes/analysis/self_energy.py
+++ b/src/arpes/analysis/self_energy.py
@@ -52,7 +52,8 @@ def get_peak_parameter(
             peak_like_components = [
                 c for c in first_item.model.components if isinstance(c, peak_like)
             ]
-            assert len(peak_like_components) == 1
+            if not (len(peak_like_components) == 1):
+                raise ValueError('Assertion failed: len(peak_like_components) == 1')
 
             return data.F.p(f"{peak_like_components[0].prefix}{parameter_name}")
         return data.F.p(parameter_name)
@@ -103,7 +104,8 @@ def estimate_bare_band(
         centers = dispersion
 
     mom_options = [d for d in dispersion.dims if d in {"k", "kp", "kx", "ky", "kz"}]
-    assert len(mom_options) <= 1
+    if not (len(mom_options) <= 1):
+        raise ValueError('Assertion failed: len(mom_options) <= 1')
     fit_dimension = "eV" if "eV" in dispersion.dims else mom_options[0]
 
     if not bare_band_specification:
@@ -117,7 +119,8 @@ def estimate_bare_band(
     elif bare_band_specification == "ransac_linear":
         min_samples = len(centers.coords[fit_dimension]) // 10
         residual = initial_linear_fit.residual
-        assert residual is not None
+        if not (residual is not None):
+            raise ValueError('Assertion failed: residual is not None')
         residual_threshold = np.median(np.abs(residual)) * 1
         _, inliers = ransac(
             np.stack([centers.coords[fit_dimension], centers]).T,
@@ -223,13 +226,15 @@ def to_self_energy(
 
     if isinstance(dispersion, xr.Dataset):
         dispersion = dispersion.results
-    assert isinstance(dispersion, xr.DataArray)
+    if not isinstance(dispersion, xr.DataArray):
+        raise TypeError('Expected dispersion to be instance of xr.DataArray')
     from_mdcs = "eV" in dispersion.dims  # if eV is in the dimensions, then we fitted MDCs
     estimated_bare_band = estimate_bare_band(dispersion, bare_band_specification="ransac_linear")
 
     if not fermi_velocity:
         fermi_velocity = local_fermi_velocity(estimated_bare_band)
-    assert isinstance(fermi_velocity, float)
+    if not isinstance(fermi_velocity, float):
+        raise TypeError('Expected fermi_velocity to be instance of float')
 
     imaginary_part = get_peak_parameter(dispersion, "fwhm") / 2
     centers = get_peak_parameter(dispersion, "center")
@@ -269,12 +274,14 @@ def fit_for_self_energy(
     Returns:
         The self energy resulting from curve-fitting.
     """
-    assert data.S.is_kspace
+    if not (data.S.is_kspace):
+        raise ValueError('Assertion failed: data.S.is_kspace')
     model = LorentzianModel() + LinearModel()
     if method == "mdc":
         possible_mometum_dims = ("kp", "kx", "ky", "kz")
         mom_axis = next(str(dim) for dim in data.dims if dim in possible_mometum_dims)
-        assert mom_axis is not None
+        if not (mom_axis is not None):
+            raise ValueError('Assertion failed: mom_axis is not None')
         model = LorentzianModel() + LinearModel()
         fit_results = data.S.modelfit(coords=mom_axis, model=model, **kwargs)
     else:

--- a/src/arpes/analysis/shirley.py
+++ b/src/arpes/analysis/shirley.py
@@ -179,7 +179,8 @@ def calculate_shirley_background(
         energy_range = slice(None, None)
 
     xps_array = xps if isinstance(xps, xr.DataArray) else normalize_to_spectrum(xps)
-    assert isinstance(xps_array, xr.DataArray)
+    if not isinstance(xps_array, xr.DataArray):
+        raise TypeError('Expected xps_array to be instance of xr.DataArray')
     xps_for_calc = xps_array.sel(eV=energy_range)
 
     bkg = calculate_shirley_background_full_range(xps_for_calc, eps, max_iters, n_samples)

--- a/src/arpes/analysis/spectrum_edges.py
+++ b/src/arpes/analysis/spectrum_edges.py
@@ -81,7 +81,8 @@ def find_spectrum_energy_edges(
         - Investigate optimal parameters for edge detection.
             (e.g., Gaussian filter size, thresholds).
     """
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     energy_marginal = data.sum([d for d in data.dims if d != "eV"])
 
     embed_size = 20
@@ -120,7 +121,8 @@ def find_spectrum_angular_edges(
         Angle position
     """
     angular_dim: str = "pixel" if "pixel" in data.dims else angle_name
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     phi_marginal = data.sum(
         [d for d in data.dims if d != angular_dim],
     )
@@ -265,10 +267,13 @@ def zero_spectrometer_edges(
         - Add tests.
 
     """
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     if low is not None:
-        assert high is not None
-        assert len(low) == len(high) == TWO_DIMENSION
+        if not (high is not None):
+            raise ValueError('Assertion failed: high is not None')
+        if not (len(low) == len(high) == TWO_DIMENSION):
+            raise ValueError('Assertion failed: len(low) == len(high) == TWO_DIMENSION')
 
         low_edges = low
         high_edges = high
@@ -286,7 +291,8 @@ def zero_spectrometer_edges(
         else:
             cut_margin = int(0.08 / data.G.stride(generic_dim_names=False)[angular_dim])
     elif isinstance(cut_margin, float):
-        assert angular_dim == "phi"
+        if not (angular_dim == "phi"):
+            raise ValueError('Assertion failed: angular_dim == "phi"')
         cut_margin = int(
             cut_margin / data.G.stride(generic_dim_names=False)[angular_dim],
         )

--- a/src/arpes/analysis/statistics.py
+++ b/src/arpes/analysis/statistics.py
@@ -50,7 +50,8 @@ def mean_and_deviation(
                 axis = pref_axis
                 break
 
-    assert axis in data.dims
+    if not (axis in data.dims):
+        raise ValueError('Assertion failed: axis in data.dims')
     return xr.Dataset(
         data_vars={name: data.mean(axis), name + "_std": data.std(axis)},
         attrs=data.attrs,

--- a/src/arpes/analysis/tarpes.py
+++ b/src/arpes/analysis/tarpes.py
@@ -153,7 +153,8 @@ def relative_change(
     """
     # Ensure DataArray + optional delay normalization
     spectrum = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(spectrum, xr.DataArray)
+    if not isinstance(spectrum, xr.DataArray):
+        raise TypeError('Expected spectrum to be instance of xr.DataArray')
     if normalize_delay:
         spectrum = normalize_dim(spectrum, "delay")
 
@@ -161,8 +162,10 @@ def relative_change(
     delay_start: float = np.min(spectrum.coords["delay"]).values.item()
     if t0 is None:
         t0 = find_t_for_max_intensity(spectrum)
-    assert t0 is not None
-    assert t0 - buffer_fs > delay_start
+    if not (t0 is not None):
+        raise ValueError('Assertion failed: t0 is not None')
+    if not (t0 - buffer_fs > delay_start):
+        raise ValueError('Assertion failed: t0 - buffer_fs > delay_start')
 
     # Subtraction
     before_t0 = spectrum.sel(delay=slice(None, t0 - buffer_fs))
@@ -194,9 +197,12 @@ def find_t_for_max_intensity(
 
     """
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(data, xr.DataArray)
-    assert "delay" in data.dims
-    assert "eV" in data.dims
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
+    if not ("delay" in data.dims):
+        raise ValueError('Assertion failed: "delay" in data.dims')
+    if not ("eV" in data.dims):
+        raise ValueError('Assertion failed: "eV" in data.dims')
     sum_dims = set(data.dims)
     sum_dims.remove("delay")
     sum_dims.remove("eV")

--- a/src/arpes/bootstrap.py
+++ b/src/arpes/bootstrap.py
@@ -205,9 +205,11 @@ def bootstrap_counts(
     Returns:
         A `xr.Dataset` which has the mean and standard error for the resampled named array.
     """
-    assert data.name is not None or name is not None
+    if not (data.name is not None or name is not None):
+        raise ValueError('Assertion failed: data.name is not None or name is not None')
     name = str(data.name) if data.name is not None else name
-    assert isinstance(name, str)
+    if not isinstance(name, str):
+        raise TypeError('Expected name to be instance of str')
     desc_fragment = f" {name}"
 
     resampled_sets = [

--- a/src/arpes/configuration/manager.py
+++ b/src/arpes/configuration/manager.py
@@ -96,7 +96,8 @@ class ConfigManager:
             )
             return
         mod = importlib.util.module_from_spec(spec)
-        assert spec.loader is not None
+        if not (spec.loader is not None):
+            raise ValueError('Assertion failed: spec.loader is not None')
         loader: Loader = spec.loader
         loader.exec_module(mod)
 
@@ -156,7 +157,8 @@ class ConfigManager:
     # --- Workspace management ---
     def enter_workspace(self, name: str) -> None:
         """Switches to a named workspace if it exists."""
-        assert isinstance(self.config["WORKSPACE"], dict)
+        if not isinstance(self.config['WORKSPACE'], dict):
+            raise TypeError("Expected self.config['WORKSPACE'] to be instance of dict")
         current: dict[str, str | Path] = self.config["WORKSPACE"]
         if not current.get("path"):
             self.detect_workspace()
@@ -198,13 +200,15 @@ class ConfigManager:
     @property
     def workspace_path(self) -> Path:
         """Returns the current workspace path as a Path object."""
-        assert isinstance(self.config["WORKSPACE"], dict)
+        if not isinstance(self.config['WORKSPACE'], dict):
+            raise TypeError("Expected self.config['WORKSPACE'] to be instance of dict")
         return Path(self.config["WORKSPACE"]["path"])
 
     @property
     def workspace_name(self) -> str | Path:
         """Returns the current workspace name."""
-        assert isinstance(self.config["WORKSPACE"], dict)
+        if not isinstance(self.config['WORKSPACE'], dict):
+            raise TypeError("Expected self.config['WORKSPACE'] to be instance of dict")
         return self.config["WORKSPACE"]["name"]
 
     def set_workspace(self, base_path: str | Path) -> None:

--- a/src/arpes/correction/angle_unit.py
+++ b/src/arpes/correction/angle_unit.py
@@ -120,7 +120,8 @@ def switched_angle_unit(data: DataType) -> DataType:
     if isinstance(data, xr.DataArray):
         return cast("DataType", switched_angle_unit_imp(data))
 
-    assert isinstance(data, xr.Dataset)
+    if not isinstance(data, xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.Dataset')
 
     data = data.copy(deep=True)
     if data.S.angle_unit is AngleUnit.RAD:
@@ -164,7 +165,8 @@ def switch_angle_unit(data: DataType) -> None:
         data.attrs.update(new.attrs)
         return
 
-    assert isinstance(data, xr.Dataset)
+    if not isinstance(data, xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.Dataset')
     new = switched_angle_unit(data)
     data.coords.update(new.coords)
     data.attrs.clear()

--- a/src/arpes/correction/background.py
+++ b/src/arpes/correction/background.py
@@ -43,7 +43,8 @@ def remove_incoherent_background(
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
     if fermi_level is None:
         fermi_level = data.S.find_spectrum_energy_edges().max()
-    assert isinstance(fermi_level, float)
+    if not isinstance(fermi_level, float):
+        raise TypeError('Expected fermi_level to be instance of float')
     logger.debug(f"fermi_level: {fermi_level}")
 
     background = data.sel(eV=slice(fermi_level + 0.1, None))

--- a/src/arpes/correction/coords.py
+++ b/src/arpes/correction/coords.py
@@ -160,8 +160,10 @@ def shift_by(
     Returns:
         xr.DataArray: The DataArray with shifted coordinates.
     """
-    assert isinstance(data, xr.DataArray)
-    assert coord_name in data.coords
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
+    if not (coord_name in data.coords):
+        raise ValueError('Assertion failed: coord_name in data.coords')
     shifted_coords = {coord_name: data.coords[coord_name] + shift_value}
     shifted_data = data.assign_coords(**shifted_coords)
     provenance_: Provenance = shifted_data.attrs.get("provenance", {})
@@ -192,7 +194,8 @@ def corrected_coords(
     corrected_data = data.copy(deep=True)
 
     for correction_type in correction_types:
-        assert correction_type in get_args(CoordsOffset)
+        if not (correction_type in get_args(CoordsOffset)):
+            raise ValueError('Assertion failed: correction_type in get_args(CoordsOffset)')
 
         if "_offset" in correction_type:
             coord_name: LiteralString = correction_type.split("_offset")[0]
@@ -232,7 +235,8 @@ def _apply_beta_theta_offset(
     data: xr.DataArray,
     correction_type: str,
 ) -> xr.DataArray:
-    assert correction_type in {"beta", "theta"}
+    if not (correction_type in {"beta", "theta"}):
+        raise ValueError('Assertion failed: correction_type in {"beta", "theta"}')
     axis = "psi" if data.S.is_slit_vertical else "phi"
     if correction_type == "beta":
         axis = "phi" if data.S.is_slit_vertical else "psi"

--- a/src/arpes/correction/fermi_edge.py
+++ b/src/arpes/correction/fermi_edge.py
@@ -76,7 +76,8 @@ def find_e_fermi_linear_dos(
     """
     if guess is None:
         guess = edc.eV.values[len(edc.eV) // 2]
-    assert isinstance(guess, float)
+    if not isinstance(guess, float):
+        raise TypeError('Expected guess to be instance of float')
 
     edc = edc - np.percentile(edc.values, (20,))[0]
     # Note that xr.Dataset.values is method not instance.
@@ -88,7 +89,8 @@ def find_e_fermi_linear_dos(
     if plot:
         if ax is None:
             _, ax = plt.subplots()
-        assert isinstance(ax, Axes)
+        if not isinstance(ax, Axes):
+            raise TypeError('Expected ax to be instance of Axes')
         edc.S.plot(ax=ax)
         ax.axvline(chemical_potential, linestyle="--", color="red")
         ax.axvline(guess, linestyle="--", color="gray")
@@ -109,7 +111,8 @@ def apply_direct_fermi_edge_correction(
         **kwargs,
     )
 
-    assert isinstance(correction, xr.Dataset)
+    if not isinstance(correction, xr.Dataset):
+        raise TypeError('Expected correction to be instance of xr.Dataset')
     shift_amount = -correction / arr.G.stride(generic_dim_names=False)["eV"]  # pylint: disable=invalid-unary-operand-type
     energy_axis_index = list(arr.dims).index("eV")
 
@@ -168,7 +171,8 @@ def build_direct_fermi_edge_correction(
     Returns:
         The array of fitted edge coordinates.
     """
-    assert len(arr.dims) == TWO_DIMENSION, "arr should be 2D."
+    if not (len(arr.dims) == TWO_DIMENSION):
+        raise ValueError('arr should be 2D.')
     edge_fit = fit_fermi_edge(arr, energy_range=energy_range).modelfit_result
 
     def sieve(_: Incomplete, v: Incomplete) -> bool:
@@ -257,7 +261,8 @@ def apply_photon_energy_fermi_edge_correction(
     """
     if correction is None:
         correction = build_photon_energy_fermi_edge_correction(arr, **kwargs)
-    assert isinstance(correction, xr.Dataset)
+    if not isinstance(correction, xr.Dataset):
+        raise TypeError('Expected correction to be instance of xr.Dataset')
     correction_values = correction.G.map(lambda x: x.params["center"].value)
     if "corrections" not in arr.attrs:
         arr.attrs["corrections"] = {}
@@ -303,7 +308,8 @@ def apply_quadratic_fermi_edge_correction(
     offset: float | None = None,
 ) -> xr.DataArray:
     """Applies a Fermi edge correction using a quadratic fit for the edge."""
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     if correction is None:
         correction = build_quadratic_fermi_edge_correction(arr)
 

--- a/src/arpes/correction/intensity_map.py
+++ b/src/arpes/correction/intensity_map.py
@@ -76,7 +76,8 @@ def shift(  # noqa: PLR0913
     Note:
         zero_nans is removed.  Use DataArray.fillna(0), if needed.
     """
-    assert shift_axis, "shift_by must take shift_axis argument."
+    if not (shift_axis):
+        raise ValueError('shift_by must take shift_axis argument.')
     shift_amount, mean_shift, by_axis = _compute_shift_amount(
         data=data,
         other=other,
@@ -151,22 +152,23 @@ def _compute_shift_amount(
             - mean_shift: The mean value of `other` (0 if not shifting coords).
             - by_axis: The determined `by_axis` name.
     """
-    assert other.ndim == 1, "`other` must be a 1D array."
+    if not (other.ndim == 1):
+        raise ValueError('`other` must be a 1D array.')
 
     mean_shift: float = 0.0
 
     if isinstance(other, xr.DataArray):
         by_axis = str(other.dims[0])
-        assert len(other.coords[by_axis]) == len(data.coords[by_axis]), (
-            "Mismatch in coordinate length."
-        )
+        if not (len(other.coords[by_axis]) == len(data.coords[by_axis])):
+            raise ValueError('Mismatch in coordinate length.')
         if shift_coords:
             mean_shift = float(np.mean(other.values))
             other = other - mean_shift
         shift_amount = -other.values / data.G.stride(generic_dim_names=False)[shift_axis]
 
     else:  # other is np.ndarray
-        assert isinstance(other, np.ndarray)
+        if not isinstance(other, np.ndarray):
+            raise TypeError('Expected other to be instance of np.ndarray')
         if not by_axis:
             if data.ndim == TWO_DIMENSION:
                 by_axis = str(set(data.dims).difference({shift_axis}).pop())
@@ -175,7 +177,8 @@ def _compute_shift_amount(
                 msg = 'When np.ndarray is used as `other`, "by_axis" is required.'
                 raise TypeError(msg)
         logger.debug(f"Using {by_axis} as by_axis for shift.")
-        assert other.shape[0] == len(data.coords[by_axis]), "Mismatch in coordinate length."
+        if not (other.shape[0] == len(data.coords[by_axis])):
+            raise ValueError('Mismatch in coordinate length.')
         if shift_coords:
             mean_shift = float(np.mean(other))
             other = other - mean_shift
@@ -202,12 +205,13 @@ def shift_by(
     Returns:
         NDArray[np.floating]: The shifted array.
     """
-    assert axis != by_axis, "`axis` and `by_axis` must be different."
+    if not (axis != by_axis):
+        raise ValueError('`axis` and `by_axis` must be different.')
     arr_copy = arr.copy()
-    assert isinstance(value, np.ndarray)
-    assert value.shape == (arr.shape[by_axis],), (
-        "`value` must have the same length as `arr` along `by_axis`."
-    )
+    if not isinstance(value, np.ndarray):
+        raise TypeError('Expected value to be instance of np.ndarray')
+    if not (value.shape == (arr.shape[by_axis],)):
+        raise ValueError('`value` must have the same length as `arr` along `by_axis`.')
     for axis_idx in range(arr.shape[by_axis]):
         slc = (slice(None),) * by_axis + (axis_idx,) + (slice(None),) * (arr.ndim - by_axis - 1)
         shift_amount = (0,) * axis + (value[axis_idx],) + (0,) * (arr.ndim - axis - 1)

--- a/src/arpes/correction/trapezoid.py
+++ b/src/arpes/correction/trapezoid.py
@@ -331,9 +331,12 @@ def trapezoid(
     Returns:
         xr.DataArray: The corrected data.
     """
-    assert isinstance(data, xr.DataArray)
-    assert "phi" in data.coords, "The data must have a phi coordinate."
-    assert len(corners) == len(("LL", "UL", "LR", "UR"))
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
+    if not ("phi" in data.coords):
+        raise ValueError('The data must have a phi coordinate.')
+    if not (len(corners) == len(("LL", "UL", "LR", "UR"))):
+        raise ValueError('Assertion failed: len(corners) == len(("LL", "UL", "LR", "UR"))')
     eV_max, eV_min = data.coords["eV"].max().item, data.coords["eV"].min().item
     if _is_all_floats(corners):
         trapezoid_corners = [
@@ -352,7 +355,8 @@ def trapezoid(
         rectangle_phis = [trapezoid_corners[1]["phi"], trapezoid_corners[3]["phi"]]
     elif rectangle_phis is None and not from_trapezoid:
         rectangle_phis = [data.coords["phi"].min().item(), data.coords["phi"].max().item()]
-    assert isinstance(rectangle_phis, list)
+    if not isinstance(rectangle_phis, list):
+        raise TypeError('Expected rectangle_phis to be instance of list')
 
     logger.debug("Determining dimensions.")
     data = data.transpose("eV", "phi", ...)
@@ -407,7 +411,8 @@ def trapezoid(
             "transforms": transforms,
         },
     )
-    assert isinstance(result, xr.DataArray)
+    if not isinstance(result, xr.DataArray):
+        raise TypeError('Expected result to be instance of xr.DataArray')
     logger.debug("Reassigning index-like coordinates.")
     return result.assign_attrs(data.attrs)
 

--- a/src/arpes/deep_learning/interpret.py
+++ b/src/arpes/deep_learning/interpret.py
@@ -58,7 +58,8 @@ class InterpretationItem:
         if isinstance(dset, Subset):
             dset = dset.dataset
 
-        assert dset.is_indexed is True
+        if not (dset.is_indexed is True):
+            raise ValueError('Assertion failed: dset.is_indexed is True')
         return dset
 
     def show(
@@ -176,7 +177,8 @@ class Interpretation:
             n_rows = math.ceil(n_items**0.5)
             layout = (n_rows, n_rows)
 
-        assert isinstance(n_items, int)
+        if not isinstance(n_items, int):
+            raise TypeError('Expected n_items to be instance of int')
         _, axes = plt.subplots(*layout, figsize=(layout[0] * 3, layout[1] * 4))
 
         items_with_nones = list(items) + [None] * (np.prod(layout) - n_items)

--- a/src/arpes/deep_learning/io.py
+++ b/src/arpes/deep_learning/io.py
@@ -55,8 +55,10 @@ def to_portable_bin(arr: NDArray[np.floating], path: Path) -> None:
     """
     path.mkdir(parents=True, exist_ok=True)
     json_path, arr_path = path / "portability.json", path / "arr.bin"
-    assert not json_path.exists()
-    assert not arr_path.exists()
+    if not (not json_path.exists()):
+        raise ValueError('Assertion failed: not json_path.exists()')
+    if not (not arr_path.exists()):
+        raise ValueError('Assertion failed: not arr_path.exists()')
 
     with Path(json_path).open("w", encoding="UTF-8") as f:
         json.dump(

--- a/src/arpes/endstations/_helper/prodigy.py
+++ b/src/arpes/endstations/_helper/prodigy.py
@@ -64,7 +64,8 @@ def parse_setscale(
     Returns:
         tuple[IgorSetscaleFlag, str, float, float, str]
     """
-    assert "SetScale" in line
+    if not ("SetScale" in line):
+        raise ValueError('Assertion failed: "SetScale" in line')
     flag: IgorSetscaleFlag
     dim: str
     num1: float

--- a/src/arpes/endstations/base.py
+++ b/src/arpes/endstations/base.py
@@ -250,7 +250,8 @@ class EndstationBase:
                 max_different_values = n_different_values
                 scan_coord = possible_scan_coord
 
-        assert isinstance(scan_coord, str)
+        if not isinstance(scan_coord, str):
+            raise TypeError('Expected scan_coord to be instance of str')
 
         for f in frames:
             f.coords[scan_coord] = f.attrs[scan_coord]

--- a/src/arpes/endstations/fits_endstation.py
+++ b/src/arpes/endstations/fits_endstation.py
@@ -137,7 +137,8 @@ class FITSEndstation(EndstationBase):
                 msg,
             )
         original_data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert original_data_loc
+        if not (original_data_loc):
+            raise ValueError('Assertion failed: original_data_loc')
         data_path = config_manager.data_path
         if not Path(original_data_loc).exists():
             if data_path is not None:

--- a/src/arpes/endstations/fits_utils.py
+++ b/src/arpes/endstations/fits_utils.py
@@ -325,8 +325,10 @@ def find_clean_coords(
         else:
             rest_shape = shape
 
-        assert len(offset) == len(delta)
-        assert len(delta) == len(rest_shape)
+        if not (len(offset) == len(delta)):
+            raise ValueError('Assertion failed: len(offset) == len(delta)')
+        if not (len(delta) == len(rest_shape)):
+            raise ValueError('Assertion failed: len(delta) == len(rest_shape)')
 
         # Build the actually coordinates
         coords = [

--- a/src/arpes/endstations/igor_utils.py
+++ b/src/arpes/endstations/igor_utils.py
@@ -33,7 +33,8 @@ def shim_wave_note(path: str | Path) -> dict[str, Any]:
     h5_out = subprocess.getoutput(cmd)
 
     split_data = h5_out[h5_out.index("DATA {") :]
-    assert len(split_data.split('"')) == 3  # noqa: PLR2004
+    if not (len(split_data.split('"')) == 3):
+        raise ValueError('Assertion failed: len(split_data.split(\'"\')) == 3')
     data = split_data.split('"')[1]
 
     # remove stuff below the end of the header

--- a/src/arpes/endstations/plugin/ALG_spin_ToF.py
+++ b/src/arpes/endstations/plugin/ALG_spin_ToF.py
@@ -107,7 +107,8 @@ class SpinToFEndstation(EndstationBase):
         data_loc = Path(scan_desc.get("path", scan_desc.get("file", "")))
         data_path = get_data_path()
         if not data_loc.is_absolute():
-            assert data_path is not None
+            if not (data_path is not None):
+                raise ValueError('Assertion failed: data_path is not None')
             data_loc = Path(data_path) / data_loc
 
         f = h5py.File(data_loc, "r")
@@ -146,7 +147,8 @@ class SpinToFEndstation(EndstationBase):
         data_loc = Path(scan_desc.get("path", scan_desc.get("file", "")))
         data_path = get_data_path()
         if not data_loc.exists():
-            assert data_path is not None
+            if not (data_path is not None):
+                raise ValueError('Assertion failed: data_path is not None')
             data_loc = Path(data_path) / data_loc
 
         hdulist = fits.open(data_loc)

--- a/src/arpes/endstations/plugin/BL10_SARPES.py
+++ b/src/arpes/endstations/plugin/BL10_SARPES.py
@@ -83,7 +83,8 @@ class BL10012SARPESEndstation(SynchrotronEndstation, HemisphericalEndstation, SE
         if scan_desc is None:
             scan_desc = {}
         original_data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert isinstance(original_data_loc, str | Path)
+        if not isinstance(original_data_loc, str | Path):
+            raise TypeError('Expected original_data_loc to be instance of str | Path')
 
         p = Path(original_data_loc)
 

--- a/src/arpes/endstations/plugin/Elettra_spectromicroscopy.py
+++ b/src/arpes/endstations/plugin/Elettra_spectromicroscopy.py
@@ -226,7 +226,8 @@ class SpectromicroscopyElettraEndstation(
                 scan_coord = possible_scan_coord
                 best_coordinates = coordinates
 
-        assert scan_coord is not None
+        if not (scan_coord is not None):
+            raise ValueError('Assertion failed: scan_coord is not None')
 
         fs = []
         for c, f in zip(best_coordinates, frames, strict=True):
@@ -252,10 +253,12 @@ class SpectromicroscopyElettraEndstation(
                 msg,
             )
         original_data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert original_data_loc is not None
+        if not (original_data_loc is not None):
+            raise ValueError('Assertion failed: original_data_loc is not None')
         if not Path(original_data_loc).exists():
             data_path = get_data_path()
-            assert data_path is not None
+            if not (data_path is not None):
+                raise ValueError('Assertion failed: data_path is not None')
             original_data_loc = Path(data_path) / original_data_loc
         p = Path(original_data_loc)
         if p.parent.parent.stem in ([*list(self._SEARCH_DIRECTORIES), "data"]):

--- a/src/arpes/endstations/plugin/HERS.py
+++ b/src/arpes/endstations/plugin/HERS.py
@@ -63,7 +63,8 @@ class HERSEndstation(
         data_loc = Path(scan_desc.get("path", scan_desc.get("file", "")))
         if not data_loc.is_absolute():
             data_path = get_data_path()
-            assert data_path is not None
+            if not (data_path is not None):
+                raise ValueError('Assertion failed: data_path is not None')
             data_loc = Path(data_path) / data_loc
 
         hdulist = fits.open(data_loc)

--- a/src/arpes/endstations/plugin/SPD_main.py
+++ b/src/arpes/endstations/plugin/SPD_main.py
@@ -167,7 +167,8 @@ class SPDEndstation(HemisphericalEndstation, SingleFileEndstation):
                 {"ID_" + str(an_array.attrs["id"]).zfill(3): an_array for an_array in data},
             )
             for spectrum in dataset:
-                assert isinstance(spectrum, xr.DataArray)
+                if not isinstance(spectrum, xr.DataArray):
+                    raise TypeError('Expected spectrum to be instance of xr.DataArray')
                 provenance_from_file(
                     child_arr=spectrum,
                     file=str(frame_path),

--- a/src/arpes/endstations/plugin/SToF_DLD.py
+++ b/src/arpes/endstations/plugin/SToF_DLD.py
@@ -53,7 +53,8 @@ class SToFDLDEndstation(EndstationBase):
         data_loc = Path(scan_desc["file"])
         if not data_loc.is_absolute():
             data_path = get_data_path()
-            assert data_path is not None
+            if not (data_path is not None):
+                raise ValueError('Assertion failed: data_path is not None')
             data_loc = Path(data_path) / data_loc
 
         f = h5py.File(data_loc, "r")

--- a/src/arpes/endstations/plugin/fallback.py
+++ b/src/arpes/endstations/plugin/fallback.py
@@ -89,9 +89,11 @@ class FallbackEndstation(EndstationBase):
         """Delegates to a dynamically chosen plugin for loading."""
         scan_desc = {} if scan_desc is None else scan_desc
         if not file:
-            assert "file" in scan_desc
+            if not ("file" in scan_desc):
+                raise ValueError('Assertion failed: "file" in scan_desc')
             file = scan_desc["file"]
-        assert isinstance(file, str | Path)
+        if not isinstance(file, str | Path):
+            raise TypeError('Expected file to be instance of str | Path')
         associated_loader = FallbackEndstation.determine_associated_loader(file)
         try:
             file_number = int(file)

--- a/src/arpes/endstations/plugin/igor_export.py
+++ b/src/arpes/endstations/plugin/igor_export.py
@@ -91,7 +91,8 @@ class IgorExportEndstation(SESEndstation):
         scan_desc = scan_desc or {}
 
         data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert data_loc is not None
+        if not (data_loc is not None):
+            raise ValueError('Assertion failed: data_loc is not None')
         if not Path(data_loc).exists():
             data_path = get_data_path()
             if data_path is not None:

--- a/src/arpes/endstations/plugin/kaindl.py
+++ b/src/arpes/endstations/plugin/kaindl.py
@@ -120,8 +120,10 @@ class KaindlEndstation(HemisphericalEndstation, SESEndstation):
             )
 
         original_data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert original_data_loc is not None
-        assert original_data_loc != ""
+        if not (original_data_loc is not None):
+            raise ValueError('Assertion failed: original_data_loc is not None')
+        if not (original_data_loc != ""):
+            raise ValueError('Assertion failed: original_data_loc != ""')
         p = Path(original_data_loc)
         if not p.exists():
             data_path = get_data_path()
@@ -148,15 +150,18 @@ class KaindlEndstation(HemisphericalEndstation, SESEndstation):
             return super().concatenate_frames(frames)
 
         # determine which axis to stitch them together along, and then do this
-        assert scan_desc
+        if not (scan_desc):
+            raise ValueError('Assertion failed: scan_desc')
         original_filename = scan_desc.get("path", scan_desc.get("file"))
-        assert original_filename is not None
+        if not (original_filename is not None):
+            raise ValueError('Assertion failed: original_filename is not None')
 
         internal_match = re.match(
             r"([a-zA-Z0-9\w+_]+)_[0-9][0-9][0-9]\.pxt",
             Path(original_filename).name,
         )
-        assert internal_match is not None
+        if not (internal_match is not None):
+            raise ValueError('Assertion failed: internal_match is not None')
         if internal_match.groups():
             motors_path = str(
                 Path(original_filename).parent / f"{internal_match.groups()[0]}_Motor_Pos.txt",
@@ -192,14 +197,17 @@ class KaindlEndstation(HemisphericalEndstation, SESEndstation):
             data (xr.DataSet): [TODO:description]
             scan_desc (ScanDesc): [TODO:description]
         """
-        assert scan_desc
+        if not (scan_desc):
+            raise ValueError('Assertion failed: scan_desc')
         original_filename = scan_desc.get("path", scan_desc.get("file"))
-        assert original_filename
+        if not (original_filename):
+            raise ValueError('Assertion failed: original_filename')
         internal_match = re.match(
             r"([a-zA-Z0-9\w+_]+_[0-9][0-9][0-9])\.pxt",
             Path(original_filename).name,
         )
-        assert internal_match is not None
+        if not (internal_match is not None):
+            raise ValueError('Assertion failed: internal_match is not None')
         all_filenames: list[Path] = find_kaindl_files_associated(Path(original_filename))
         all_filenames = [f.parent / f"{f.stem}_AI.txt" for f in all_filenames]
 

--- a/src/arpes/endstations/plugin/merlin.py
+++ b/src/arpes/endstations/plugin/merlin.py
@@ -131,7 +131,8 @@ class BL403ARPESEndstation(SynchrotronEndstation, HemisphericalEndstation, SESEn
             scan_desc = {}
         # determine which axis to stitch them together along, and then do this
         original_filename = scan_desc.get("file", scan_desc.get("path"))
-        assert original_filename is not None
+        if not (original_filename is not None):
+            raise ValueError('Assertion failed: original_filename is not None')
 
         internal_match = re.match(
             r"([a-zA-Z0-9\w+_]+)_[S][0-9][0-9][0-9]\.pxt",

--- a/src/arpes/endstations/registry.py
+++ b/src/arpes/endstations/registry.py
@@ -52,7 +52,8 @@ def add_endstation(endstation_cls: type[EndstationBase]) -> None:
     You can use this to add a plugin after the original search if it is defined in another
     module or in a notebook.
     """
-    assert endstation_cls.PRINCIPAL_NAME is not None
+    if not (endstation_cls.PRINCIPAL_NAME is not None):
+        raise ValueError('Assertion failed: endstation_cls.PRINCIPAL_NAME is not None')
     for alias in endstation_cls.ALIASES:
         if alias in _ENDSTATION_ALIASES:
             continue

--- a/src/arpes/endstations/ses_endstation.py
+++ b/src/arpes/endstations/ses_endstation.py
@@ -53,7 +53,8 @@ class SESEndstation(EndstationBase):
             )
 
         original_data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert original_data_loc
+        if not (original_data_loc):
+            raise ValueError('Assertion failed: original_data_loc')
         config_manager = get_config_manager()
         if not Path(original_data_loc).exists():
             if config_manager.data_path is not None:
@@ -132,7 +133,8 @@ class SESEndstation(EndstationBase):
         scan_desc = scan_desc or {}
 
         data_loc = scan_desc.get("path", scan_desc.get("file"))
-        assert data_loc is not None
+        if not (data_loc is not None):
+            raise ValueError('Assertion failed: data_loc is not None')
         config_manager = get_config_manager()
         if not Path(data_loc).exists():
             if config_manager.data_path is not None:

--- a/src/arpes/endstations/single_file_endstation.py
+++ b/src/arpes/endstations/single_file_endstation.py
@@ -51,7 +51,8 @@ class SingleFileEndstation(EndstationBase):
         if original_data_loc is None:
             msg = "No file path found in scan description."
             raise ValueError(msg)
-        assert original_data_loc
+        if not (original_data_loc):
+            raise ValueError('Assertion failed: original_data_loc')
         if not Path(original_data_loc).exists():
             data_path = get_data_path()
             if data_path is not None:

--- a/src/arpes/export/itx.py
+++ b/src/arpes/export/itx.py
@@ -97,7 +97,8 @@ def convert_itx_format(
         stacklevel=2,
     )
 
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     if "User Comment" in arr.attrs:
         arr.attrs["User Comment"] += ";" + _user_comment_from_attrs(arr)
     else:

--- a/src/arpes/fits/fit_models/two_dimensional.py
+++ b/src/arpes/fits/fit_models/two_dimensional.py
@@ -141,7 +141,8 @@ class EffectiveMassModel(Model):
         **kwargs: Incomplete,
     ) -> lf.Parameters:
         """Use heuristics to estimate the model parameters."""
-        assert isinstance(eV, xr.DataArray)
+        if not isinstance(eV, xr.DataArray):
+            raise TypeError('Expected eV to be instance of xr.DataArray')
         momentum = kp.values
         eV_arr = eV.values
         data_arr = data.values

--- a/src/arpes/helper/jupyter.py
+++ b/src/arpes/helper/jupyter.py
@@ -137,7 +137,8 @@ def get_recent_history(n_items: int = 10) -> list[str]:
     """Fetches recent cell evaluations for context on provenance outputs."""
     try:
         ipython = get_ipython()
-        assert isinstance(ipython, InteractiveShell)
+        if not isinstance(ipython, InteractiveShell):
+            raise TypeError('Expected ipython to be instance of InteractiveShell')
         return [
             _[-1]
             for _ in list(
@@ -147,7 +148,7 @@ def get_recent_history(n_items: int = 10) -> list[str]:
                 ),
             )
         ]
-    except (AttributeError, AssertionError):
+    except (AttributeError, AssertionError, TypeError):
         return ["No accessible history."]
 
 
@@ -157,11 +158,13 @@ def get_recent_logs(n_bytes: int = 1000) -> list[str]:
 
     try:
         ipython = get_ipython()
-        assert isinstance(ipython, InteractiveShell)
+        if not isinstance(ipython, InteractiveShell):
+            raise TypeError('Expected ipython to be instance of InteractiveShell')
         logging_started = get_logging_started()
         if logging_started:
             logging_file = get_logging_file()
-            assert isinstance(logging_file, str | Path)
+            if not isinstance(logging_file, str | Path):
+                raise TypeError('Expected logging_file to be instance of str | Path')
             with Path(logging_file).open("rb") as file:
                 try:
                     file.seek(-n_bytes, SEEK_END)
@@ -177,7 +180,7 @@ def get_recent_logs(n_bytes: int = 1000) -> list[str]:
             )[0][-1]
             return [_.decode() for _ in lines] + [final_cell]
 
-    except (AttributeError, AssertionError):
+    except (AttributeError, AssertionError, TypeError):
         pass
 
     return ["No logging available. Logging is only available inside Jupyter."]

--- a/src/arpes/io.py
+++ b/src/arpes/io.py
@@ -77,7 +77,8 @@ def load_data(
             stacklevel=2,
         )
     except ValueError:
-        assert isinstance(file, (str | Path))
+        if not isinstance(file, str | Path):
+            raise TypeError('Expected file to be instance of str | Path')
         file = str(Path(file).absolute())
 
     desc: ScanDesc = {
@@ -195,7 +196,8 @@ def stitch(
     """
     list_of_files = _df_or_list_to_files(df_or_list)
     if not built_axis_name:
-        assert isinstance(attr_or_axis, str)
+        if not isinstance(attr_or_axis, str):
+            raise TypeError('Expected attr_or_axis to be instance of str')
         built_axis_name = attr_or_axis
     if not list_of_files:
         msg = "Must supply at least one file to stitch"
@@ -214,13 +216,15 @@ def stitch(
             value = data.coords[attr_or_axis]
         loaded.append(data.assign_coords({built_axis_name: value}))
 
-    assert all(isinstance(data, xr.DataArray) for data in loaded) or all(
+    if not (all(isinstance(data, xr.DataArray) for data in loaded) or all(
         isinstance(data, xr.Dataset) for data in loaded
-    )
+    )):
+        raise ValueError('Assertion failed: all(isinstance(data, xr.DataArray) for data in loaded) or all(\n        isinstance(data, xr.Dataset) for data in loaded\n    )')
 
     if sort:
         loaded.sort(key=lambda x: np.min(x.coords[built_axis_name].values))
-    assert isinstance(loaded, Iterable)
+    if not isinstance(loaded, Iterable):
+        raise TypeError('Expected loaded to be instance of Iterable')
     concatenated = xr.concat(loaded, dim=built_axis_name)
     if "id" in concatenated.attrs:
         del concatenated.attrs["id"]
@@ -249,10 +253,11 @@ def _df_or_list_to_files(
     """
     if isinstance(df_or_list, pd.DataFrame):
         return list(df_or_list.index)
-    assert not isinstance(
+    if not (not isinstance(
         df_or_list,
         list | tuple,
-    ), "Expected an iterable for a list of the scans to stitch together"
+    )):
+        raise ValueError('Expected an iterable for a list of the scans to stitch together')
     return list(df_or_list)
 
 
@@ -307,10 +312,12 @@ def easy_pickle(data_or_str: str | object, name: str = "") -> object:
     """
     # we are loading data
     if isinstance(data_or_str, str) or not name:
-        assert isinstance(data_or_str, str)
+        if not isinstance(data_or_str, str):
+            raise TypeError('Expected data_or_str to be instance of str')
         return load_pickle(data_or_str)
     # we are saving data
-    assert isinstance(name, str)
+    if not isinstance(name, str):
+        raise TypeError('Expected name to be instance of str')
     save_pickle(data_or_str, name)
     return None
 
@@ -349,7 +356,8 @@ def load_scan(
     """
     note: dict[str, str | float] | ScanDesc = scan_desc.get("note", scan_desc)
     full_note: ScanDesc = copy.deepcopy(scan_desc)
-    assert isinstance(note, dict)
+    if not isinstance(note, dict):
+        raise TypeError('Expected note to be instance of dict')
     full_note.update(cast("ScanDesc", note))
 
     endstation_cls = resolve_endstation(retry=retry, **full_note)

--- a/src/arpes/models/band.py
+++ b/src/arpes/models/band.py
@@ -102,7 +102,8 @@ class Band:
         clean: bool = True,
     ) -> xr.DataArray | NDArray[np.floating]:
         """Converts the underlying data into an array representation."""
-        assert isinstance(self._data, xr.Dataset)
+        if not isinstance(self._data, xr.Dataset):
+            raise TypeError('Expected self._data to be instance of xr.Dataset')
         if not clean:
             return self._data[var_name].values
 
@@ -119,46 +120,53 @@ class Band:
     def center(self) -> xr.DataArray:
         """Gets the peak location along the band."""
         center_array = self.get_dataarray("center")
-        assert isinstance(center_array, xr.DataArray)
+        if not isinstance(center_array, xr.DataArray):
+            raise TypeError('Expected center_array to be instance of xr.DataArray')
         return center_array
 
     @property
     def center_stderr(self) -> NDArray[np.floating]:
         """Gets the peak location stderr along the band."""
         center_stderr = self.get_dataarray("center_stderr", clean=False)
-        assert isinstance(center_stderr, np.ndarray)
+        if not isinstance(center_stderr, np.ndarray):
+            raise TypeError('Expected center_stderr to be instance of np.ndarray')
         return center_stderr
 
     @property
     def sigma(self) -> xr.DataArray:
         """Gets the peak width along the band."""
         sigma_array = self.get_dataarray("sigma", clean=True)
-        assert isinstance(sigma_array, xr.DataArray)
+        if not isinstance(sigma_array, xr.DataArray):
+            raise TypeError('Expected sigma_array to be instance of xr.DataArray')
         return sigma_array
 
     @property
     def amplitude(self) -> xr.DataArray:
         """Gets the peak amplitude along the band."""
         amplitude_array = self.get_dataarray("amplitude", clean=True)
-        assert isinstance(amplitude_array, xr.DataArray)
+        if not isinstance(amplitude_array, xr.DataArray):
+            raise TypeError('Expected amplitude_array to be instance of xr.DataArray')
         return amplitude_array
 
     @property
     def indexes(self) -> Indexes:
         """Fetches the indices of the originating data (after fit reduction)."""
-        assert isinstance(self._data, xr.Dataset)
+        if not isinstance(self._data, xr.Dataset):
+            raise TypeError('Expected self._data to be instance of xr.Dataset')
         return self._data.center.indexes
 
     @property
     def coords(self) -> DataArrayCoordinates:
         """Fetches the coordinates of the originating data (after fit reduction)."""
-        assert isinstance(self._data, xr.Dataset)
+        if not isinstance(self._data, xr.Dataset):
+            raise TypeError('Expected self._data to be instance of xr.Dataset')
         return self._data.center.coords
 
     @property
     def dims(self) -> tuple[str, ...]:
         """Fetches the dimensions of the originating data (after fit reduction)."""
-        assert isinstance(self._data, xr.Dataset)
+        if not isinstance(self._data, xr.Dataset):
+            raise TypeError('Expected self._data to be instance of xr.Dataset')
         return self._data.center.dims
 
     @staticmethod
@@ -186,7 +194,8 @@ class MultifitBand(Band):
 
     def get_dataarray(self, var_name: str, *, clean: bool = True) -> xr.DataArray:
         """Converts the underlying data into an array representation."""
-        assert isinstance(self._data, xr.DataArray | xr.Dataset)
+        if not isinstance(self._data, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._data to be instance of xr.DataArray | xr.Dataset')
         full_var_name = self.label + var_name
         if not clean:
             pass

--- a/src/arpes/plotting/annotations.py
+++ b/src/arpes/plotting/annotations.py
@@ -183,8 +183,10 @@ def annotate_cuts(
     )
 
     converted_coordinates = convert_coordinates_to_kspace_forward(data)
-    assert isinstance(converted_coordinates, xr.Dataset)
-    assert len(plotted_axes) == TWO_DIMENSION
+    if not isinstance(converted_coordinates, xr.Dataset):
+        raise TypeError('Expected converted_coordinates to be instance of xr.Dataset')
+    if not (len(plotted_axes) == TWO_DIMENSION):
+        raise ValueError('Assertion failed: len(plotted_axes) == TWO_DIMENSION')
 
     for k, v in kwargs.items():
         selected = converted_coordinates.sel({k: v}, method="nearest")
@@ -223,12 +225,14 @@ def annotate_point(
         }.get(kwargs["label"], "")
         kwargs.pop("label")
 
-    assert isinstance(delta, tuple)
+    if not isinstance(delta, tuple):
+        raise TypeError('Expected delta to be instance of tuple')
     if "color" not in kwargs:
         kwargs["color"] = "red"
 
     if len(delta) == TWO_DIMENSION:
-        assert isinstance(ax, Axes)
+        if not isinstance(ax, Axes):
+            raise TypeError('Expected ax to be instance of Axes')
         dx, dy = tuple(delta)
         pos_x, pos_y = tuple(location)
         ax.plot(
@@ -244,7 +248,8 @@ def annotate_point(
             **kwargs,
         )
     else:
-        assert isinstance(ax, Axes3D)
+        if not isinstance(ax, Axes3D):
+            raise TypeError('Expected ax to be instance of Axes3D')
         dx, dy, dz = tuple(delta)
         pos_x, pos_y, pos_z = tuple(location)
         ax.plot(

--- a/src/arpes/plotting/bands.py
+++ b/src/arpes/plotting/bands.py
@@ -51,14 +51,16 @@ def plot_with_bands(
     if ax is None:
         _, ax = plt.subplots(figsize=(8, 5))
 
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     if not title:
         title = data.S.label.replace("_", " ")
 
     mesh: AxesImage = data.S.plot(ax=ax, **kwargs)
     mesh_colorbar = mesh.colorbar
-    assert isinstance(mesh_colorbar, colorbar.Colorbar)
+    if not isinstance(mesh_colorbar, colorbar.Colorbar):
+        raise TypeError('Expected mesh_colorbar to be instance of colorbar.Colorbar')
     mesh_colorbar.set_label(label_for_colorbar(data))
 
     if data.S.is_differentiated:

--- a/src/arpes/plotting/basic.py
+++ b/src/arpes/plotting/basic.py
@@ -42,7 +42,8 @@ def make_overview(
     Returns: tuple[Figure, list[Axes]]
         Overview of ARPES data.
     """
-    assert isinstance(data_all, Sequence)
+    if not isinstance(data_all, Sequence):
+        raise TypeError('Expected data_all to be instance of Sequence')
     num_figs = len(data_all)
     nrows = num_figs // ncols
     if num_figs % ncols:

--- a/src/arpes/plotting/bz.py
+++ b/src/arpes/plotting/bz.py
@@ -229,8 +229,10 @@ def plot_data_to_bz2d(  # noqa: PLR0913
     Returns:
         [TODO:description]
     """
-    assert data_array.S.is_kspace, "You must k-space convert data before plotting to BZs"
-    assert isinstance(data_array, xr.DataArray), "data_array must be xr.DataArray, not Dataset"
+    if not (data_array.S.is_kspace):
+        raise ValueError('You must k-space convert data before plotting to BZs')
+    if not isinstance(data_array, xr.DataArray):
+        raise TypeError('data_array must be xr.DataArray, not Dataset')
 
     if bz_number is None:
         bz_number = (0, 0)
@@ -239,7 +241,8 @@ def plot_data_to_bz2d(  # noqa: PLR0913
     if ax is None:
         fig, ax = plt.subplots(figsize=(9, 9))
         bz_plot(cell, paths="all", ax=ax)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     icell = cell.reciprocal()
 
@@ -294,7 +297,8 @@ def bz2d_segments(
     """Calculates the line segments corresponding to a 2D BZ."""
     segments_x = []
     segments_y = []
-    assert cell.rank == TWO_DIMENSION
+    if not (cell.rank == TWO_DIMENSION):
+        raise ValueError('Assertion failed: cell.rank == TWO_DIMENSION')
 
     for points, _ in twocell_to_bz1(cell)[0]:
         transformed_points = apply_transformations(points, transformations)

--- a/src/arpes/plotting/coordinates.py
+++ b/src/arpes/plotting/coordinates.py
@@ -45,7 +45,8 @@ def remap_coords_to(
         keep_attrs=True,
     )  # sum is not so fast, but ensures there is data
 
-    assert arr.S.is_kspace == reference_arr.S.is_kspace
+    if not (arr.S.is_kspace == reference_arr.S.is_kspace):
+        raise ValueError('Assertion failed: arr.S.is_kspace == reference_arr.S.is_kspace')
 
     full_coords = arr.S.full_coords
     full_reference_coords = reference_arr.S.full_coords

--- a/src/arpes/plotting/decoration.py
+++ b/src/arpes/plotting/decoration.py
@@ -51,21 +51,24 @@ def h_gradient_fill(
     """
     if ax is None:
         ax = plt.gca()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     alpha = float(kwargs.get("alpha", 1.0))
     kwargs.setdefault("aspect", "auto")
     kwargs.setdefault("origin", "lower")
     step = kwargs.pop("step", None)
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
-    assert fill_color
+    if not (fill_color):
+        raise ValueError('Assertion failed: fill_color')
 
     z = np.empty((1, 100, 4), dtype=float)
 
     rgb = colorConverter.to_rgb(fill_color)
     z[:, :, :3] = rgb
     z[:, :, -1] = np.linspace(0, alpha, 100)[None, :]
-    assert x1 < x2
+    if not (x1 < x2):
+        raise ValueError('Assertion failed: x1 < x2')
     xmin, xmax, (ymin, ymax) = x1, x2, ylim
     kwargs.setdefault("extent", (xmin, xmax, ymin, ymax))
 
@@ -121,20 +124,23 @@ def v_gradient_fill(
         ax = plt.gca()
 
     alpha = float(kwargs.get("alpha", 1.0))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     kwargs.setdefault("aspect", "auto")
     kwargs.setdefault("origin", "lower")
     step = kwargs.pop("step", None)
 
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
-    assert fill_color
+    if not (fill_color):
+        raise ValueError('Assertion failed: fill_color')
 
     z = np.empty((100, 1, 4), dtype=float)
 
     rgb = colorConverter.to_rgb(fill_color)
     z[:, :, :3] = rgb
     z[:, :, -1] = np.linspace(0, alpha, 100)[:, None]
-    assert y1 < y2
+    if not (y1 < y2):
+        raise ValueError('Assertion failed: y1 < y2')
     (xmin, xmax), ymin, ymax = xlim, y1, y2
     kwargs.setdefault("extent", (xmin, xmax, ymin, ymax))
     im: AxesImage = ax.imshow(

--- a/src/arpes/plotting/dispersion.py
+++ b/src/arpes/plotting/dispersion.py
@@ -101,8 +101,10 @@ def cut_dispersion_plot(  # noqa: PLR0913, PLR0915  # type: ignore[arg-type]
         "low": 40,
     }.get(quality, 100)
 
-    assert "eV" in data.dims
-    assert e_floor is not None
+    if not ("eV" in data.dims):
+        raise ValueError('Assertion failed: "eV" in data.dims')
+    if not (e_floor is not None):
+        raise ValueError('Assertion failed: e_floor is not None')
 
     new_dim_order = list(data.dims)
     new_dim_order.remove("eV")
@@ -140,7 +142,8 @@ def cut_dispersion_plot(  # noqa: PLR0913, PLR0915  # type: ignore[arg-type]
     if ax is None:
         fig: FigureBase = plt.figure(figsize=(7, 7))
         ax = fig.add_subplot(1, 1, 1, projection="3d")
-    assert isinstance(ax, Axes3D)
+    if not isinstance(ax, Axes3D):
+        raise TypeError('Expected ax to be instance of Axes3D')
 
     kwargs.setdefault(
         "title",
@@ -340,7 +343,8 @@ def hv_reference_scan(
     out = kwargs.pop("out", None)
 
     lfs = labeled_fermi_surface(fs, **kwargs)
-    assert isinstance(lfs, tuple)
+    if not isinstance(lfs, tuple):
+        raise TypeError('Expected lfs to be instance of tuple')
     _, ax = lfs
 
     all_scans = data.attrs["df"]
@@ -398,7 +402,8 @@ def reference_scan_fermi_surface(
 
     out = kwargs.pop("out", None)
     lfs = labeled_fermi_surface(fs, **kwargs)
-    assert isinstance(lfs, tuple)
+    if not isinstance(lfs, tuple):
+        raise TypeError('Expected lfs to be instance of tuple')
     _, ax = lfs
 
     referenced_scans = data.S.referenced_scans
@@ -436,11 +441,13 @@ def labeled_fermi_surface(  # noqa: PLR0913
     fermi_energy: float = 0,
 ) -> Path | tuple[Figure | None, Axes]:
     """Plots a Fermi surface with high symmetry points annotated onto it."""
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     fig = None
     if ax is None:
         fig, ax = plt.subplots(figsize=(7.0, 7.0))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     if not title:
         title = "{} Fermi Surface".format(data.S.label.replace("_", " "))
@@ -525,7 +532,8 @@ def fancy_dispersion(
     """
     if ax is None:
         _, ax = plt.subplots(figsize=(8, 5))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     if not title:
         title = data.S.label.replace("_", " ")
 
@@ -544,7 +552,8 @@ def fancy_dispersion(
     marker_color = "RdBu" if data.S.is_differentiated else "red"
     if include_symmetry_points:
         for point_name, point_locations in data.attrs.get("symmetry_points", {}).items():
-            assert isinstance(point_locations, list | tuple)
+            if not isinstance(point_locations, list | tuple):
+                raise TypeError('Expected point_locations to be instance of list | tuple')
             for single_location in point_locations:
                 coords = (
                     single_location[original_x_label],
@@ -597,10 +606,12 @@ def scan_var_reference_plot(
     Returns:
         Axes | Path: The Axes object containing the plot, or the file path if the plot is saved.
     """
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     if ax is None:
         _, ax = plt.subplots(figsize=(8, 5))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     if not title:
         title = data.S.label.replace("_", " ")
 

--- a/src/arpes/plotting/dos.py
+++ b/src/arpes/plotting/dos.py
@@ -136,12 +136,14 @@ def plot_core_levels(  # noqa: PLR0913
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     data.S.plot(ax=ax, **kwargs)
 
     if core_levels is None:
         core_levels = approximate_core_levels(data, binning=binning, promenance=promenance)
-    assert core_levels is not None
+    if not (core_levels is not None):
+        raise ValueError('Assertion failed: core_levels is not None')
     for core_level in core_levels:
         ax.axvline(core_level, ymin=0.1, ymax=0.25, color="red", ls="-")
 
@@ -175,8 +177,10 @@ def plot_dos(
             axes.
     """
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(data, xr.DataArray)
-    assert data.ndim == TWO_DIMENSION
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
+    if not (data.ndim == TWO_DIMENSION):
+        raise ValueError('Assertion failed: data.ndim == TWO_DIMENSION')
     dos = data.S.sum_other(["eV"], keep_attrs=True)
     kwargs.setdefault(
         "norm",
@@ -222,8 +226,10 @@ def plot_dos(
         ax0.set_xlabel(str(data.dims[1]))
         ax1.set_xlabel("Intensity")
     ax0.set_ylabel(str(data.dims[0]))
-    assert "norm" in kwargs
-    assert isinstance(kwargs["norm"], Normalize | None)
+    if not ("norm" in kwargs):
+        raise ValueError('Assertion failed: "norm" in kwargs')
+    if not isinstance(kwargs['norm'], Normalize | None):
+        raise TypeError("Expected kwargs['norm'] to be instance of Normalize | None")
 
     if out:
         savefig(str(out), dpi=400)

--- a/src/arpes/plotting/false_color.py
+++ b/src/arpes/plotting/false_color.py
@@ -53,7 +53,8 @@ def false_color_plot(  # noqa: PLR0913
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     def normalize_channel(channel: NDArray[np.floating]) -> NDArray[np.float64]:
         channel -= np.percentile(channel, 100 * pmin)

--- a/src/arpes/plotting/fermi_edge.py
+++ b/src/arpes/plotting/fermi_edge.py
@@ -52,7 +52,8 @@ def fermi_edge_reference(
         "Not automatically correcting for slit shape distortions to the Fermi edge",
         stacklevel=2,
     )
-    assert isinstance(data_arr, xr.DataArray)
+    if not isinstance(data_arr, xr.DataArray):
+        raise TypeError('Expected data_arr to be instance of xr.DataArray')
     if len(data_arr.dims) > TWO_DIMENSION:
         sum_dimensions: set[str] = {"cycle", "phi", "kp", "kx"}
         sum_dimensions.intersection_update(set(data_arr.dims))
@@ -60,7 +61,8 @@ def fermi_edge_reference(
             *list(sum_dimensions),
             keep_attrs=True,
         )
-        assert any(str(d) == "eV" for d in data_for_fit.dims)
+        if not (any(str(d) == "eV" for d in data_for_fit.dims)):
+            raise ValueError('Assertion failed: any(str(d) == "eV" for d in data_for_fit.dims)')
     else:
         data_for_fit = data_arr
     edge_fit = fit_fermi_edge(data_for_fit, energy_range=energy_range)
@@ -75,7 +77,8 @@ def fermi_edge_reference(
 
     if ax is None:
         _, ax = plt.subplots(figsize=(8, 5))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     if not title:
         title = data_arr.S.label.replace("_", " ")

--- a/src/arpes/plotting/fermi_surface.py
+++ b/src/arpes/plotting/fermi_surface.py
@@ -106,13 +106,15 @@ def magnify_circular_regions_plot(  # noqa: PLR0913
         A tuple of figure and axes, or the path to the saved plot.
     """
     data_arr = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(data_arr, xr.DataArray)
+    if not isinstance(data_arr, xr.DataArray):
+        raise TypeError('Expected data_arr to be instance of xr.DataArray')
 
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots(figsize=kwargs.pop("figsize", (7, 5)))
 
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     mesh = data_arr.S.plot(ax=ax, cmap=cmap)
     clim = list(mesh.get_clim())

--- a/src/arpes/plotting/fits.py
+++ b/src/arpes/plotting/fits.py
@@ -38,10 +38,12 @@ def plot_fit(model_result: lf.model.ModelResult, ax: Axes | None = None) -> Axes
     """
     if ax is None:
         _, ax = plt.subplots()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     x = model_result.userkws[model_result.model.independent_vars[0]]
     ax2 = ax.twinx()
-    assert isinstance(ax2, Axes)
+    if not isinstance(ax2, Axes):
+        raise TypeError('Expected ax2 to be instance of Axes')
     ax2.grid(visible=False)
     ax2.axhline(0, color="green", linestyle="--", alpha=0.5)
 

--- a/src/arpes/plotting/movie.py
+++ b/src/arpes/plotting/movie.py
@@ -74,13 +74,13 @@ def output_animation(  # noqa: PLR0913
     if out is Ellipsis:
         return anim
 
-    if isinstance(out, str | Path):
+    if isinstance(out, (str, Path)):
         logger.debug(msg=f"path_for_plot is {path_for_plot(out)}")
         anim.save(str(path_for_plot(out)))
         return path_for_plot(out)
 
-    assert update_func is not None
-    assert fig is not None
+    if update_func is None or fig is None:
+        raise ValueError("Both 'update_func' and 'fig' must be provided when 'out' is not a path or Ellipsis.")
     if isinstance(out, Number):
         index: int = data.indexes[time_dim].get_indexer([out], method="nearest")[0]
         update_func(index)
@@ -102,10 +102,14 @@ def _initialize_figure_and_axes(
         figsize=figsize,
         width_ratios=width_ratio,
     )
-    assert ax is not None
-    assert isinstance(ax[0], Axes)
-    assert isinstance(ax[1], Axes)
-    assert isinstance(fig, Figure)
+    if ax is None:
+        raise RuntimeError("Failed to create axes for plotting.")
+    if not (hasattr(ax, '__len__') and len(ax) >= 2):
+        raise TypeError("Expected 'ax' to be an array-like with two Axes objects.")
+    if not isinstance(ax[0], Axes) or not isinstance(ax[1], Axes):
+        raise TypeError("Elements of 'ax' are not matplotlib.axes.Axes instances.")
+    if not isinstance(fig, Figure):
+        raise TypeError("fig is not a matplotlib.figure.Figure instance.")
     return fig, ax
 
 
@@ -147,7 +151,7 @@ def plot_movie_and_evolution(  # noqa: PLR0913
     labels: tuple[str, str, str] | None = None,
     **kwargs: Unpack[PColorMeshKwargs],
 ) -> Path | HTML | Figure | FuncAnimation:
-    """Create an animatied plot of ARPES data with time evolution at certain position.
+    """Create an animated plot of ARPES data with time evolution at certain position.
 
     This function uses matplotlib's pcolormesh to create the plots.
 
@@ -181,7 +185,8 @@ def plot_movie_and_evolution(  # noqa: PLR0913
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
 
     fig, ax = _initialize_figure_and_axes(fig_ax, figsize, width_ratio)
-    assert data.ndim == TWO_DIMENSION + 1
+    if data.ndim != TWO_DIMENSION + 1:
+        raise ValueError(f"Expected data with ndim == {TWO_DIMENSION + 1}, got {data.ndim}")
 
     kwargs.setdefault(
         "cmap",
@@ -197,7 +202,8 @@ def plot_movie_and_evolution(  # noqa: PLR0913
             method="nearest",
         ).transpose(..., time_dim)
     else:
-        assert isinstance(evolution_at[1], tuple)
+        if not isinstance(evolution_at[1], tuple):
+            raise TypeError('Expected evolution_at[1] to be instance of tuple')
         start, half_width = evolution_at[1]
         evolution_data = (
             data.sel(
@@ -321,10 +327,14 @@ def plot_movie(  # noqa: PLR0913
     figsize = figsize or (9.0, 5.0)
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
     fig, ax = fig_ax or plt.subplots(figsize=figsize)
-    assert isinstance(ax, Axes)
-    assert isinstance(fig, Figure)
-    assert isinstance(data, xr.DataArray)
-    assert data.ndim == TWO_DIMENSION + 1
+    if not isinstance(ax, Axes):
+        raise TypeError("ax must be a matplotlib.axes.Axes instance.")
+    if not isinstance(fig, Figure):
+        raise TypeError("fig must be a matplotlib.figure.Figure instance.")
+    if not isinstance(data, xr.DataArray):
+        raise TypeError("data must be an xarray.DataArray.")
+    if data.ndim != TWO_DIMENSION + 1:
+        raise ValueError(f"Expected data with ndim == {TWO_DIMENSION + 1}, got {data.ndim}")
 
     kwargs.setdefault(
         "cmap",
@@ -394,10 +404,10 @@ def plot_movie(  # noqa: PLR0913
 
 
 def _replace_after_col(array: NDArray[np.floating], col_num: int) -> NDArray[np.floating]:
-    """Replace elements in the array with NaN af ter a specified column.
+    """Replace elements in the array with NaN after a specified column.
 
     Args:
-        array (NDArray[np.floating): The input array.
+        array (NDArray[np.floating]): The input array.
         col_num (int): The column number after which elements will be replaced with NaN.
 
     Returns:

--- a/src/arpes/plotting/parameter.py
+++ b/src/arpes/plotting/parameter.py
@@ -52,7 +52,8 @@ def plot_parameter(  # noqa: PLR0913
     """
     if ax is None:
         _, ax = plt.subplots(figsize=figsize)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     ds = fit_data.F.param_as_dataset(param_name)
     x_name = ds.value.dims[0]

--- a/src/arpes/plotting/spatial.py
+++ b/src/arpes/plotting/spatial.py
@@ -100,7 +100,8 @@ def plot_spatial_reference(  # noqa: PLR0913, C901, PLR0912, PLR0915  # Might be
     reference_map = reference_map.S.mean_other(["x", "y", "z"])
 
     ref_dims: tuple[Hashable, ...] = reference_map.dims[::-1]
-    assert len(reference_map.dims) == TWO_DIMENSION
+    if not (len(reference_map.dims) == TWO_DIMENSION):
+        raise ValueError('Assertion failed: len(reference_map.dims) == TWO_DIMENSION')
     reference_map.S.plot(ax=ax, cmap="Blues")
 
     cmap = mpl.colormaps.get_cmap("Reds")
@@ -222,7 +223,8 @@ def reference_scan_spatial(
     """
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
 
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
 
     dims = [d for d in data.dims if d in {"cycle", "phi", "eV"}]
 

--- a/src/arpes/plotting/spin.py
+++ b/src/arpes/plotting/spin.py
@@ -52,7 +52,8 @@ def spin_colored_spectrum(
     """
     if ax is None:
         _, ax = plt.subplots(figsize=(6, 4))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     as_intensity = to_intensity_polarization(spin_dr)
     intensity = as_intensity.intensity
     pol = as_intensity.polarization.copy(deep=True)
@@ -92,7 +93,8 @@ def spin_colored_spectrum(
 
 def _polarization_colorbar(ax: Axes | None = None) -> colorbar.Colorbar:
     """Makes a colorbar which is appropriate for "polarization" (e.g. spin) data."""
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     return colorbar.Colorbar(
         ax,
         cmap="RdBu",
@@ -115,7 +117,8 @@ def spin_difference_spectrum(
     """Plots a spin difference spectrum."""
     if ax is None:
         _, ax = plt.subplots(figsize=(6, 4))
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     try:
         as_intensity = to_intensity_polarization(spin_dr)
     except AssertionError:
@@ -170,7 +173,8 @@ def spin_polarized_spectrum(  # noqa: PLR0913
     """Plots a simple spin polarized spectrum using curves for the up and down components."""
     if ax is None:
         _, ax = plt.subplots(2, 1, sharex=True)
-    assert ax is not None
+    if not (ax is not None):
+        raise ValueError('Assertion failed: ax is not None')
 
     if stats:
         spin_dr = bootstrap(lambda x: x)(spin_dr, N=100)
@@ -301,14 +305,18 @@ def hue_brightness_plot(
 
 
     """
-    assert "intensity" in data
-    assert "polarization" in data
+    if not ("intensity" in data):
+        raise ValueError('Assertion failed: "intensity" in data')
+    if not ("polarization" in data):
+        raise ValueError('Assertion failed: "polarization" in data')
 
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots(figsize=kwargs.get("figsize", (7, 5)))
-    assert isinstance(ax, Axes)
-    assert isinstance(fig, Figure)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
+    if not isinstance(fig, Figure):
+        raise TypeError('Expected fig to be instance of Figure')
     x, y = data.coords[data.intensity.dims[0]].values, data.coords[data.intensity.dims[1]].values
     extent = (y[0], y[-1], x[0], x[-1])
     ax.imshow(

--- a/src/arpes/plotting/stack_plot.py
+++ b/src/arpes/plotting/stack_plot.py
@@ -128,8 +128,10 @@ def waterfall_dispersion(  # noqa: PLR0913
             ax_right.yaxis.label.set_text(stack_axis)
 
     """
-    assert data.ndim == TWO_DIMENSION
-    assert scale_factor >= 0, "scale factor should be positive."
+    if not (data.ndim == TWO_DIMENSION):
+        raise ValueError('Assertion failed: data.ndim == TWO_DIMENSION')
+    if not (scale_factor >= 0):
+        raise ValueError('scale factor should be positive.')
 
     fig: Figure | None = None
     if ax is None:
@@ -316,18 +318,22 @@ def offset_scatter_plot(  # noqa: PLR0913
     Raises:
         ValueError
     """
-    assert isinstance(data, xr.Dataset)
+    if not isinstance(data, xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.Dataset')
 
     if not name_to_plot:
         var_names = [k for k in data.data_vars if "_std" not in str(k)]  # => ["spectrum"]
-        assert len(var_names) == 1
+        if not (len(var_names) == 1):
+            raise ValueError('Assertion failed: len(var_names) == 1')
         name_to_plot = str(var_names[0])
-        assert (name_to_plot + "_std") in data.data_vars, "Has 'mean_and_deviation' been applied?"
+        if not ((name_to_plot + "_std") in data.data_vars):
+            raise ValueError("Has 'mean_and_deviation' been applied?")
 
     msg = "In order to produce a stack plot, data must be image-like."
     msg += "Passed data included dimensions:"
     msg += f" {data.data_vars[name_to_plot].dims}"
-    assert len(data.data_vars[name_to_plot].dims) == TWO_DIMENSION, msg
+    if not (len(data.data_vars[name_to_plot].dims) == TWO_DIMENSION):
+        raise ValueError('Assertion failed: len(data.data_vars[name_to_plot].dims) == TWO_DIMENSION')
 
     fig: Figure | None = None
     if ax is None:
@@ -335,7 +341,8 @@ def offset_scatter_plot(  # noqa: PLR0913
 
     inset_ax = inset_axes(ax, width="40%", height="5%", loc=loc)
 
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     stack_axis = stack_axis or str(data.data_vars[name_to_plot].dims[0])
 
@@ -475,7 +482,8 @@ def flat_stack_plot(  # noqa: PLR0913 #pragma: no cover
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
     ax_inset = inset_axes(ax, width="40%", height="5%", loc=loc)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     if not stack_axis:
         stack_axis = str(data.dims[0])
 
@@ -503,10 +511,12 @@ def flat_stack_plot(  # noqa: PLR0913 #pragma: no cover
                 **kwargs,
             )
         else:
-            assert mode == "scatter"
+            if not (mode == "scatter"):
+                raise ValueError('Assertion failed: mode == "scatter"')
             kwargs["color"] = _color_for_plot(color, i, len(data.coords[stack_axis]))
             ax.scatter(horizontal, marginal.values, **kwargs)
-    assert isinstance(color, str | Colormap)
+    if not isinstance(color, str | Colormap):
+        raise TypeError('Expected color to be instance of str | Colormap')
     matplotlib.colorbar.Colorbar(
         ax_inset,
         orientation="horizontal",
@@ -584,7 +594,8 @@ def stack_dispersion_plot(  # noqa: PLR0913  # pragma: no cover
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
 
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     if not title:
         title = (
             f"ID: {data_arr.S.parent_id} Stack"
@@ -754,7 +765,8 @@ def _rebinning(
     3. determine the name of the other.
     """
     data_arr = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-    assert isinstance(data_arr, xr.DataArray)
+    if not isinstance(data_arr, xr.DataArray):
+        raise TypeError('Expected data_arr to be instance of xr.DataArray')
     if len(data.dims) != TWO_DIMENSION:
         msg = "In order to produce a stack plot, data must be image-like."
         msg += f"Passed data included dimensions: {data.dims}"

--- a/src/arpes/plotting/tof.py
+++ b/src/arpes/plotting/tof.py
@@ -64,16 +64,17 @@ def plot_with_std(
     """
     if not name_to_plot:
         var_names = [k for k in data_set.data_vars if "_std" not in str(k)]
-        assert len(var_names) == 1
+        if not (len(var_names) == 1):
+            raise ValueError('Assertion failed: len(var_names) == 1')
         name_to_plot = str(var_names[0])
-        assert (name_to_plot + "_std") in data_set.data_vars, (
-            "Has 'mean_and_deviation' been applied?"
-        )
+        if not ((name_to_plot + "_std") in data_set.data_vars):
+            raise ValueError("Has 'mean_and_deviation' been applied?")
 
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     data_set.data_vars[name_to_plot].S.plot(ax=ax, **kwargs)
     x, y = data_set.data_vars[name_to_plot].coords["eV"], data_set.data_vars[name_to_plot].values
@@ -112,16 +113,17 @@ def scatter_with_std(
     """
     if not name_to_plot:
         var_names = [k for k in data.data_vars if "_std" not in str(k)]
-        assert len(var_names) == 1
+        if not (len(var_names) == 1):
+            raise ValueError('Assertion failed: len(var_names) == 1')
         name_to_plot = str(var_names[0])
-        assert (name_to_plot + "_std") in data.data_vars, (
-            "Has 'mean_and_deviation' been applied to the data?"
-        )
+        if not ((name_to_plot + "_std") in data.data_vars):
+            raise ValueError("Has 'mean_and_deviation' been applied to the data?")
 
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     x, y = data.data_vars[name_to_plot].coords["eV"], data.data_vars[name_to_plot].values
 
     std = data.data_vars[name_to_plot + "_std"].values

--- a/src/arpes/plotting/ui/base.py
+++ b/src/arpes/plotting/ui/base.py
@@ -117,7 +117,8 @@ class BaseUI(ABC):
             method to construct its specific user interface components.
         """
         data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
-        assert len(data.dims) <= TWO_DIMENSION
+        if not (len(data.dims) <= TWO_DIMENSION):
+            raise ValueError('Assertion failed: len(data.dims) <= TWO_DIMENSION')
         self.pane_kwargs = default_plot_kwargs(**kwargs)
 
         self.data: xr.DataArray = data
@@ -188,15 +189,18 @@ def image_with_pointer(
     """
     kwargs = default_plot_kwargs(**kwargs)
 
-    assert data.ndim == TWO_DIMENSION
+    if not (data.ndim == TWO_DIMENSION):
+        raise ValueError('Assertion failed: data.ndim == TWO_DIMENSION')
     data = fix_xarray_to_fit_with_holoview(data)
     max_coords = data.G.argmax_coords()
 
     posx = posx or PointerX(x=max_coords[data.dims[0]])
     posy = posy or PointerY(y=max_coords[data.dims[1]])
 
-    assert isinstance(posx, PointerX)
-    assert isinstance(posy, PointerY)
+    if not isinstance(posx, PointerX):
+        raise TypeError('Expected posx to be instance of PointerX')
+    if not isinstance(posy, PointerY):
+        raise TypeError('Expected posy to be instance of PointerY')
 
     data = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
 

--- a/src/arpes/plotting/ui/combine.py
+++ b/src/arpes/plotting/ui/combine.py
@@ -62,9 +62,12 @@ class TailorApp(BaseUI):
             **kwargs: Additional parameters for the UI, such as pane_kwargs.
         """
         super().__init__(data, data_b, **kwargs)
-        assert isinstance(data_b, xr.DataArray), "Data must be an xarray DataArray."
-        assert data.ndim == TWO_DIMENSION, "Data must be two dimensions."
-        assert data_b.ndim == TWO_DIMENSION, "Data must be two dimensions."
+        if not isinstance(data_b, xr.DataArray):
+            raise TypeError('Data must be an xarray DataArray.')
+        if not (data.ndim == TWO_DIMENSION):
+            raise ValueError('Data must be two dimensions.')
+        if not (data_b.ndim == TWO_DIMENSION):
+            raise ValueError('Data must be two dimensions.')
 
         self._build()
 

--- a/src/arpes/plotting/ui/fit.py
+++ b/src/arpes/plotting/ui/fit.py
@@ -75,7 +75,8 @@ def fit_inspection(
     kwargs = default_plot_kwargs(**kwargs)
     kwargs.setdefault("profile_view_height", 200)
 
-    assert any(str(i).endswith("modelfit_data") for i in dataset.data_vars)
+    if not (any(str(i).endswith("modelfit_data") for i in dataset.data_vars)):
+        raise ValueError('Assertion failed: any(str(i).endswith("modelfit_data") for i in dataset.data_vars)')
     if any(str(i).startswith("modelfit_data") for i in dataset.data_vars):
         exp_data = dataset["modelfit_data"]
     else:

--- a/src/arpes/plotting/utils.py
+++ b/src/arpes/plotting/utils.py
@@ -129,8 +129,10 @@ def mod_plot_to_ax(
         mod (lmfit.model.Model): Fitting model function
         **kwargs(): pass to "ax.plot"
     """
-    assert isinstance(data_arr, xr.DataArray)
-    assert isinstance(ax, Axes)
+    if not isinstance(data_arr, xr.DataArray):
+        raise TypeError('Expected data_arr to be instance of xr.DataArray')
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     with unchanged_limits(ax):
         xs: NDArray[np.floating] = data_arr.coords[data_arr.dims[0]].values
         ys: NDArray[np.floating] = mod.eval(x=xs)
@@ -218,7 +220,8 @@ def data_to_axis_units(
     """Converts from data coordinates to axis coordinates (figure pixcels)."""
     if ax is None:
         ax = plt.gca()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     return ax.transAxes.inverted().transform(ax.transData.transform(points))
 
 
@@ -229,7 +232,8 @@ def axis_to_data_units(
     """Converts from axis coordinate to data coorinates."""
     if ax is None:
         ax = plt.gca()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     return ax.transData.inverted().transform(ax.transAxes.transform(points))
 
 
@@ -269,15 +273,18 @@ def summarize(
         3: (2, 2),  # one extra here
         4: (3, 2),  # corresponds to 4 choose 2 axes
     }
-    assert len(data.dims) <= len(axes_shapes_for_dims)
+    if not (len(data.dims) <= len(axes_shapes_for_dims)):
+        raise ValueError('Assertion failed: len(data.dims) <= len(axes_shapes_for_dims)')
     if axes is None:
         n_rows, n_cols = axes_shapes_for_dims.get(len(data.dims), (3, 2))
         _, axes = plt.subplots(nrows=n_rows, ncols=n_cols, figsize=(8, 8))
-    assert isinstance(axes, np.ndarray)
+    if not isinstance(axes, np.ndarray):
+        raise TypeError('Expected axes to be instance of np.ndarray')
     flat_axes = axes.ravel()
     combinations = list(itertools.combinations(data.dims, 2))
     for axi, combination in zip(flat_axes, combinations, strict=False):
-        assert isinstance(axi, Axes)
+        if not isinstance(axi, Axes):
+            raise TypeError('Expected axi to be instance of Axes')
         data.sum(combination).S.plot(ax=axi)
         fancy_labels(axi)
 
@@ -372,7 +379,8 @@ def quick_tex(
     """
     if ax is None:
         _, ax = plt.subplots()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     invisible_axes(ax)
     ax.text(0.2, 0.2, latex_fragment, fontsize=fontsize)
@@ -390,10 +398,12 @@ def lineplot_arr(
     """Convenience method to plot an array with a mask over some other data."""
     if mask_kwargs is None:
         mask_kwargs = {}
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     if ax is None:
         _, ax = plt.subplots()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     xs = None
     if arr is not None:
@@ -425,7 +435,8 @@ def plot_arr(
 ) -> Axes | None:
     """Convenience method to plot an array with a mask over some other data."""
     to_plot = arr if mask is None else mask
-    assert isinstance(to_plot, xr.Dataset)
+    if not isinstance(to_plot, xr.Dataset):
+        raise TypeError('Expected to_plot to be instance of xr.Dataset')
     try:
         n_dims = len(to_plot.dims)
     except AttributeError:
@@ -437,10 +448,12 @@ def plot_arr(
             _, quad = imshow_arr(arr, ax=ax, over=over, **kwargs)
         if mask is not None:
             over = quad if over is None else over
-            assert isinstance(mask, xr.DataArray)
+            if not isinstance(mask, xr.DataArray):
+                raise TypeError('Expected mask to be instance of xr.DataArray')
             imshow_mask(mask, ax=ax, over=over, **kwargs)
     if n_dims == 1:
-        assert isinstance(mask, list | None)
+        if not isinstance(mask, list | None):
+            raise TypeError('Expected mask to be instance of list | None')
         ax = lineplot_arr(arr, ax=ax, mask=mask, **kwargs)
 
     return ax
@@ -465,11 +478,13 @@ def pcolormesh_mask(
 
     Todo: Consider better handling of NaN values and transparency.
     """
-    assert over is not None
+    if not (over is not None):
+        raise ValueError('Assertion failed: over is not None')
 
     if ax is None:
         ax = plt.gca()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     default_kwargs = {
         "alpha": 1.0,
@@ -482,8 +497,10 @@ def pcolormesh_mask(
 
     if "cmap" in kwargs and isinstance(kwargs["cmap"], str):
         kwargs["cmap"] = mpl.colormaps.get_cmap(cmap=kwargs["cmap"])
-    assert "cmap" in kwargs
-    assert isinstance(kwargs["cmap"], Colormap)
+    if not ("cmap" in kwargs):
+        raise ValueError('Assertion failed: "cmap" in kwargs')
+    if not isinstance(kwargs['cmap'], Colormap):
+        raise TypeError("Expected kwargs['cmap'] to be instance of Colormap")
     kwargs["cmap"].set_bad("k", alpha=0)
     masked_data = np.where(np.isnan(mask.values), np.nan, mask.values)
 
@@ -505,11 +522,13 @@ def imshow_mask(
 
     Todo: Consider using pcolormesh or removing this function.
     """
-    assert over is not None
+    if not (over is not None):
+        raise ValueError('Assertion failed: over is not None')
 
     if ax is None:
         ax = plt.gca()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     default_kwargs: IMshowParam = {
         "origin": "lower",
@@ -527,8 +546,10 @@ def imshow_mask(
     if "cmap" in kwargs and isinstance(kwargs["cmap"], str):
         kwargs["cmap"] = mpl.colormaps.get_cmap(cmap=kwargs["cmap"])
 
-    assert "cmap" in kwargs
-    assert isinstance(kwargs["cmap"], Colormap)
+    if not ("cmap" in kwargs):
+        raise ValueError('Assertion failed: "cmap" in kwargs')
+    if not isinstance(kwargs['cmap'], Colormap):
+        raise TypeError("Expected kwargs['cmap'] to be instance of Colormap")
     kwargs["cmap"].set_bad("k", alpha=0)
 
     ax.imshow(
@@ -560,7 +581,8 @@ def imshow_arr(
     fig: Figure | None = None
     if ax is None:
         fig, ax = plt.subplots()
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     x, y = arr.coords[arr.dims[0]].values, arr.coords[arr.dims[1]].values
     default_kwargs: IMshowParam = {
@@ -574,12 +596,18 @@ def imshow_arr(
     }
     for k, v in default_kwargs.items():
         kwargs.setdefault(k, v)  # type: ignore[misc]
-    assert "alpha" in kwargs
-    assert "cmap" in kwargs
-    assert "vmin" in kwargs
-    assert "vmax" in kwargs
-    assert isinstance(kwargs["vmin"], float)
-    assert isinstance(kwargs["vmax"], float)
+    if not ("alpha" in kwargs):
+        raise ValueError('Assertion failed: "alpha" in kwargs')
+    if not ("cmap" in kwargs):
+        raise ValueError('Assertion failed: "cmap" in kwargs')
+    if not ("vmin" in kwargs):
+        raise ValueError('Assertion failed: "vmin" in kwargs')
+    if not ("vmax" in kwargs):
+        raise ValueError('Assertion failed: "vmax" in kwargs')
+    if not isinstance(kwargs['vmin'], float):
+        raise TypeError("Expected kwargs['vmin'] to be instance of float")
+    if not isinstance(kwargs['vmax'], float):
+        raise TypeError("Expected kwargs['vmax'] to be instance of float")
     if over is None:
         if kwargs["alpha"] != 1:
             norm = colors.Normalize(vmin=kwargs["vmin"], vmax=kwargs["vmax"])
@@ -668,15 +696,18 @@ def insert_cut_locator(
     Todo: Follow the docs.  (Rename from inset_cut_locator)
     """
     quad = data.S.plot(ax=ax)
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
 
     ax.set_xlabel("")
     ax.set_ylabel("")
     with contextlib.suppress(Exception):
         quad.colorbar.remove()
 
-    assert isinstance(data, xr.Dataset | xr.DataArray)
-    assert isinstance(reference_data, xr.Dataset | xr.DataArray)
+    if not isinstance(data, xr.Dataset | xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.Dataset | xr.DataArray')
+    if not isinstance(reference_data, xr.Dataset | xr.DataArray):
+        raise TypeError('Expected reference_data to be instance of xr.Dataset | xr.DataArray')
     # add more as necessary
     missing_dim_resolvers = {
         "theta": lambda: reference_data.S.theta,
@@ -716,7 +747,8 @@ def insert_cut_locator(
     )
 
     if missing_dims:
-        assert reference_data is not None
+        if not (reference_data is not None):
+            raise ValueError('Assertion failed: reference_data is not None')
         logger.info(missing_dims)
 
     if n_cut_dims == TWO_DIMENSION:
@@ -772,7 +804,8 @@ def calculate_aspect_ratio(data: xr.DataArray) -> float:
     """Calculate the aspect ratio which should be used for plotting some data based on extent."""
     data_arr = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
 
-    assert len(data.dims_arr) == TWO_DIMENSION
+    if not (len(data.dims_arr) == TWO_DIMENSION):
+        raise ValueError('Assertion failed: len(data.dims_arr) == TWO_DIMENSION')
 
     x_extent = np.ptp(data_arr.coords[data_arr.dims[0]].values)
     y_extent = np.ptp(data_arr.coords[data_arr.dims[1]].values)
@@ -807,7 +840,8 @@ class AnchoredHScaleBar(AnchoredOffsetbox):
         """Setup the scale bar and coordinate transforms to the parent axis."""
         if not ax:
             ax = plt.gca()
-        assert isinstance(ax, Axes)
+        if not isinstance(ax, Axes):
+            raise TypeError('Expected ax to be instance of Axes')
         trans = ax.get_xaxis_transform()
 
         size_bar = AuxTransformBox(trans)
@@ -862,7 +896,8 @@ def savefig(
 
     """
     desired_path = Path(desired_path)
-    assert isinstance(desired_path, Path)
+    if not isinstance(desired_path, Path):
+        raise TypeError('Expected desired_path to be instance of Path')
     if not desired_path.suffix:
         paper = True
 
@@ -918,10 +953,8 @@ def savefig(
         return for_data.attrs.get("provenance", {})
 
     if data is not None:
-        assert isinstance(
-            data,
-            list | tuple | set,
-        )
+        if not isinstance(data, list | tuple | set):
+            raise TypeError('Expected data to be instance of list | tuple | set')
         provenance_context["jupyter_context"] = get_recent_history(1)
         provenance_context["data"] = [extract_provenance(d) for d in data]
     else:
@@ -1158,8 +1191,10 @@ def label_for_dim(
             "spectrum": "Intensity ( arb. )",
         }
         if isinstance(data, xr.Dataset | xr.DataArray):
-            assert isinstance(data, xr.Dataset | xr.DataArray)
-            assert isinstance(data, HasSAccessor)
+            if not isinstance(data, xr.Dataset | xr.DataArray):
+                raise TypeError('Expected data to be instance of xr.Dataset | xr.DataArray')
+            if not isinstance(data, HasSAccessor):
+                raise TypeError('Expected data to be instance of HasSAccessor')
             if data.S.energy_notation == "Final":
                 raw_dim_names["eV"] = r"Final State Energy ( eV )"
             else:
@@ -1188,7 +1223,8 @@ def label_for_dim(
             "spectrum": "Intensity ( arb. )",
         }
         if isinstance(data, xr.DataArray | xr.Dataset):
-            assert isinstance(data, HasSAccessor)
+            if not isinstance(data, HasSAccessor):
+                raise TypeError('Expected data to be instance of HasSAccessor')
             if data.S.energy_notation == "Final":
                 raw_dim_names["eV"] = "Final State Energy ( eV )"
             else:
@@ -1219,7 +1255,8 @@ def fancy_labels(
         return
 
     ax = ax_or_ax_set
-    assert isinstance(ax, Axes)
+    if not isinstance(ax, Axes):
+        raise TypeError('Expected ax to be instance of Axes')
     ax.set_xlabel(label_for_dim(data=data, dim_name=ax.get_xlabel()))
 
     with contextlib.suppress(Exception):

--- a/src/arpes/preparation/axis.py
+++ b/src/arpes/preparation/axis.py
@@ -53,14 +53,16 @@ def vstack_data(
     """
     if not all(new_dim in data.attrs for data in arr_list):
         logger.debug(f"{new_dim} is not included")
-        assert all(new_dim in data.coords for data in arr_list)
+        if not (all(new_dim in data.coords for data in arr_list)):
+            raise ValueError('Assertion failed: all(new_dim in data.coords for data in arr_list)')
     else:
         arr_list = [data.assign_coords({new_dim: data.attrs[new_dim]}) for data in arr_list]
 
     if sort:
         arr_list = sorted(arr_list, key=lambda x: x.coords[new_dim].values.item())
 
-    assert is_homogeneous_dataarray_list(arr_list) or is_homogeneous_dataset_list(arr_list)
+    if not (is_homogeneous_dataarray_list(arr_list) or is_homogeneous_dataset_list(arr_list)):
+        raise ValueError('Assertion failed: is_homogeneous_dataarray_list(arr_list) or is_homogeneous_dataset_list(arr_list)')
     concatenated_data: DataType = cast("DataType", xr.concat(arr_list, dim=new_dim))
     if new_dim in concatenated_data.attrs:
         del concatenated_data.attrs[new_dim]
@@ -79,7 +81,8 @@ def sort_axis(data: xr.DataArray, axis_name: str) -> xr.DataArray:
         xr.DataArray: The sorted xarray data.orts slices of `data` along `axis_name` so that they
             lie in order.
     """
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     copied = data.copy(deep=True)
     coord = data.coords[axis_name].values
     order = np.argsort(coord)
@@ -141,7 +144,8 @@ def normalize_dim(
     """
     dims: list[str]
     dims = [dim_or_dims] if isinstance(dim_or_dims, str) else dim_or_dims
-    assert isinstance(dims, list)
+    if not isinstance(dims, list):
+        raise TypeError('Expected dims to be instance of list')
 
     summed_arr = arr.fillna(arr.mean()).sum(
         [d for d in arr.dims if d not in dims],
@@ -200,7 +204,8 @@ def normalize_max(
             values * max_value,
             keep_attrs=keep_attrs,
         )
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError('Expected data to be instance of xr.DataArray')
     return data
 
 
@@ -216,7 +221,8 @@ def normalize_total(data: XrTypes, *, total_intensity: float = 1000000) -> xr.Da
         xr.DataArray
     """
     data_array = normalize_to_spectrum(data)
-    assert isinstance(data_array, xr.DataArray)
+    if not isinstance(data_array, xr.DataArray):
+        raise TypeError('Expected data_array to be instance of xr.DataArray')
     return data_array / (data_array.sum(data.dims) / total_intensity)
 
 
@@ -279,7 +285,8 @@ def transform_dataarray_axis(  # noqa: PLR0913
 
     ds = dataset.copy()
     transform_spectra = {k: v for k, v in ds.data_vars.items() if old_axis_name in v.dims}
-    assert isinstance(transform_spectra, dict)
+    if not isinstance(transform_spectra, dict):
+        raise TypeError('Expected transform_spectra to be instance of dict')
 
     ds.coords[new_axis_name] = new_axis
 
@@ -326,7 +333,8 @@ def transform_dataarray_axis(  # noqa: PLR0913
         if remove_old:
             del ds[name]
         else:
-            assert prep_name(name) != name, "You must make sure names don't collide"
+            if not (prep_name(name) != name):
+                raise ValueError("You must make sure names don't collide")
 
     new_ds = xr.merge([ds, *new_dataarrays])
 

--- a/src/arpes/preparation/coord.py
+++ b/src/arpes/preparation/coord.py
@@ -27,7 +27,8 @@ def disambiguate_coordinates(
     """
     coords_set: dict[str, list[xr.DataArray]] = collections.defaultdict(list)
     for spectrum in datasets:
-        assert isinstance(spectrum, xr.DataArray)
+        if not isinstance(spectrum, xr.DataArray):
+            raise TypeError('Expected spectrum to be instance of xr.DataArray')
         for c in possibly_clashing_coordinates:
             if c in spectrum.coords:
                 coords_set[c].append(spectrum.coords[c])
@@ -47,7 +48,8 @@ def disambiguate_coordinates(
 
     after_deconflict: list[xr.DataArray] = []
     for spectrum in datasets:
-        assert isinstance(spectrum, xr.DataArray)
+        if not isinstance(spectrum, xr.DataArray):
+            raise TypeError('Expected spectrum to be instance of xr.DataArray')
         spectrum_name = next(iter(spectrum.data_vars.keys()))
         to_rename = {
             name: str(name) + "-" + spectrum_name for name in spectrum.dims if name in conflicted

--- a/src/arpes/preparation/hemisphere.py
+++ b/src/arpes/preparation/hemisphere.py
@@ -41,7 +41,8 @@ def stitch_maps(
     for i, (lower, higher) in enumerate(pairwise(coord1)):
         if higher > first_repair_coordinate:
             break
-        assert isinstance(i, int)
+        if not isinstance(i, int):
+            raise TypeError('Expected i to be instance of int')
         delta_low, delta_high = lower - first_repair_coordinate, higher - first_repair_coordinate
     if abs(delta_low) < abs(delta_high):
         delta = delta_low

--- a/src/arpes/preparation/tof.py
+++ b/src/arpes/preparation/tof.py
@@ -52,7 +52,8 @@ def convert_to_kinetic_energy(
     new_dim_order[0] = "eV"
 
     timing: NDArray[np.floating] = dataarray.coords["time"].values
-    assert timing[1] > timing[0]
+    if not (timing[1] > timing[0]):
+        raise ValueError('Assertion failed: timing[1] > timing[0]')
     t_min, t_max = timing.min().item(), timing.max().item()
 
     # Prep arrays

--- a/src/arpes/provenance.py
+++ b/src/arpes/provenance.py
@@ -299,7 +299,8 @@ def provenance(
         record: An annotation to add.
     """
     if isinstance(parents, list):
-        assert len(parents) == 1
+        if not (len(parents) == 1):
+            raise ValueError('Assertion failed: len(parents) == 1')
         parents = parents[0]
 
     if "id" not in child_arr.attrs:

--- a/src/arpes/simulation.py
+++ b/src/arpes/simulation.py
@@ -295,8 +295,10 @@ class SpectralFunction:
         if omega is None:
             omega = np.linspace(-1000, 1000, 2000, dtype=np.float64)
 
-        assert isinstance(k, np.ndarray)
-        assert isinstance(omega, np.ndarray)
+        if not isinstance(k, np.ndarray):
+            raise TypeError('Expected k to be instance of np.ndarray')
+        if not isinstance(omega, np.ndarray):
+            raise TypeError('Expected omega to be instance of np.ndarray')
 
         self.temperature = temperature
         self.omega = omega

--- a/src/arpes/utilities/bz.py
+++ b/src/arpes/utilities/bz.py
@@ -239,7 +239,8 @@ def axis_along(data: XrTypes, symbol: str) -> float:
         if np.abs(dD) > max_value:
             max_value = np.abs(dD)
             max_dim = d
-    assert isinstance(max_dim, float)
+    if not isinstance(max_dim, float):
+        raise TypeError('Expected max_dim to be instance of float')
     return max_dim
 
 
@@ -342,7 +343,8 @@ def reduced_bz_E_mask(
         if np.all(poly_points[:, i] == poly_points[0, i]):
             skip_col = i
 
-    assert skip_col is not None
+    if not (skip_col is not None):
+        raise ValueError('Assertion failed: skip_col is not None')
     selector_val = poly_points[0, skip_col]
     poly_points = np.concatenate(
         (poly_points[:, 0:skip_col], poly_points[:, skip_col + 1 :]),

--- a/src/arpes/utilities/combine.py
+++ b/src/arpes/utilities/combine.py
@@ -32,10 +32,13 @@ def concat_along_phi(
     Returns:
         Concatenated ARPES array
     """
-    assert isinstance(arr_a, xr.DataArray)
-    assert isinstance(arr_b, xr.DataArray)
+    if not isinstance(arr_a, xr.DataArray):
+        raise TypeError('Expected arr_a to be instance of xr.DataArray')
+    if not isinstance(arr_b, xr.DataArray):
+        raise TypeError('Expected arr_b to be instance of xr.DataArray')
     if occupation_ratio is not None:
-        assert 0 <= occupation_ratio <= 1, "occupation_ratio should be between 0 and 1 (or None)."
+        if not (0 <= occupation_ratio <= 1):
+            raise ValueError('occupation_ratio should be between 0 and 1 (or None).')
     id_arr_a = attach_id(arr_a)
     id_arr_b = attach_id(arr_b)
     arr_a = arr_a.G.with_values(arr_a.values * enhance_a)
@@ -57,9 +60,8 @@ def concat_along_phi(
             raise RuntimeError(
                 msg,
             )
-        assert left_arr.coords["phi"].values.max() < right_arr.coords["phi"].values.max(), (
-            'Cannot combine them. Try "occupation_ration=None"'
-        )
+        if not (left_arr.coords["phi"].values.max() < right_arr.coords["phi"].values.max()):
+            raise ValueError('Cannot combine them. Try "occupation_ration=None"')
         seam_phi = (
             left_arr.coords["phi"].values.max() - right_arr.coords["phi"].values.min()
         ) * occupation_ratio + right_arr.coords["phi"].values.min()

--- a/src/arpes/utilities/conversion/api.py
+++ b/src/arpes/utilities/conversion/api.py
@@ -145,12 +145,14 @@ def convert_to_kspace(  # noqa: PLR0913
         xr.DataArray: Converted ARPES (k-space) data.
     """
     coords = {} if coords is None else coords
-    assert coords is not None
+    if not (coords is not None):
+        raise ValueError('Assertion failed: coords is not None')
     coords.update(kwargs)
 
     bounds = bounds or {}
     arr = arr if isinstance(arr, xr.DataArray) else normalize_to_spectrum(arr)
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     if arr.S.angle_unit is AngleUnit.DEG:
         arr = arr.S.switched_angle_unit()
     logger.debug(f"bounds (covnert_to_kspace): {bounds}")
@@ -196,7 +198,8 @@ def convert_to_kspace(  # noqa: PLR0913
             # ('chi', 'phi',): ConvertKxKy,
             ("hv", "phi"): ConvertKpKz,
         }.get(tupled_momentum_compatibles)
-    assert convert_cls is not None, "Cannot select convert class"
+    if not (convert_cls is not None):
+        raise ValueError('Cannot select convert class')
 
     converter: CoordinateConverter = convert_cls(
         arr=arr,
@@ -221,7 +224,8 @@ def convert_to_kspace(  # noqa: PLR0913
             "transforms": {str(dim): converter.conversion_for(dim) for dim in arr.dims},
         },
     )
-    assert isinstance(result, xr.DataArray)
+    if not isinstance(result, xr.DataArray):
+        raise TypeError('Expected result to be instance of xr.DataArray')
     return result
 
 
@@ -268,7 +272,8 @@ def _chunk_convert(
         )
         if "eV" not in kchunk.dims:
             kchunk = kchunk.expand_dims("eV")
-        assert isinstance(kchunk, xr.DataArray)
+        if not isinstance(kchunk, xr.DataArray):
+            raise TypeError('Expected kchunk to be instance of xr.DataArray')
         finished.append(kchunk)
         low_idx = high_idx
         high_idx = min(len(arr.eV), high_idx + chunk_thickness)

--- a/src/arpes/utilities/conversion/base.py
+++ b/src/arpes/utilities/conversion/base.py
@@ -92,7 +92,8 @@ class CoordinateConverter:
         cache computations as they arrive. This is the technique that is used in
         ConvertKxKy below
         """
-        assert isinstance(arr, xr.DataArray)
+        if not isinstance(arr, xr.DataArray):
+            raise TypeError('Expected arr to be instance of xr.DataArray')
 
     @property
     def is_slit_vertical(self) -> bool:
@@ -138,9 +139,8 @@ class CoordinateConverter:
 
         Useful if the transform is the identity.
         """
-        assert isinstance(self.dim_order, (list | tuple)), (
-            f"self.dim_oder should be list | tuple, but {type(self.dim_order)}"
-        )
+        if not isinstance(self.dim_order, list | tuple):
+            raise TypeError('Expected self.dim_order to be instance of list | tuple')
         return args[self.dim_order.index(str(axis_name))]
 
     @abstractmethod

--- a/src/arpes/utilities/conversion/bounds_calculations.py
+++ b/src/arpes/utilities/conversion/bounds_calculations.py
@@ -210,7 +210,8 @@ def calculate_kp_kz_bounds(arr: xr.DataArray) -> tuple[tuple[float, float], tupl
         spherical_to_kx(hv_min - binding_energy_max - wf, phi_max, 0.0),
     )
     angle_max = max(abs(phi_min), abs(phi_max))
-    assert isinstance(angle_max, float)
+    if not isinstance(angle_max, float):
+        raise TypeError('Expected angle_max to be instance of float')
     inner_V = arr.S.inner_potential
     kz_min = spherical_to_kz(hv_min + binding_energy_min - wf, angle_max, inner_V)
     kz_max = spherical_to_kz(hv_max + binding_energy_max - wf, 0.0, inner_V)

--- a/src/arpes/utilities/conversion/calibration.py
+++ b/src/arpes/utilities/conversion/calibration.py
@@ -33,10 +33,11 @@ class DetectorCalibration:
 
     def __init__(self, left: list[dict[str, float]], right: list[dict[str, float]]) -> None:
         """Build the edges for the calibration from a path for the left and right sides."""
-        assert set(left[0].keys()) == {
+        if not (set(left[0].keys()) == {
             "phi",
             "eV",
-        }
+        }):
+            raise ValueError('Assertion failed: set(left[0].keys()) == {\n            "phi",\n            "eV",\n        }')
         self._left_edge = build_edge_from_list(left)
         self._right_edge = build_edge_from_list(right)
         # if the edges were passed incorrectly then do it ourselves

--- a/src/arpes/utilities/conversion/coordinates.py
+++ b/src/arpes/utilities/conversion/coordinates.py
@@ -146,7 +146,8 @@ def convert_coordinates(
     Returns:
         XrTypes
     """
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     ordered_source_dimensions = arr.dims
 
     grid_interpolator = grid_interpolator_from_dataarray(
@@ -171,7 +172,8 @@ def convert_coordinates(
         with contextlib.suppress(ValueError):
             meshed_coordinates = [arr.S.lookup_offset_coord("eV"), *meshed_coordinates]
     old_coord_names = [str(dim) for dim in arr.dims if dim not in target_coordinates]
-    assert isinstance(coordinate_transform["transforms"], dict)
+    if not isinstance(coordinate_transform['transforms'], dict):
+        raise TypeError("Expected coordinate_transform['transforms'] to be instance of dict")
     transforms: dict[str, Callable[..., NDArray[np.floating]]] = coordinate_transform["transforms"]
     logger.debug(f"transforms is {transforms}")
     old_coordinate_transforms = [

--- a/src/arpes/utilities/conversion/core.py
+++ b/src/arpes/utilities/conversion/core.py
@@ -53,7 +53,8 @@ def grid_interpolator_from_dataarray(
 
     This is principally used for coordinate translations.
     """
-    assert isinstance(arr, xr.DataArray)
+    if not isinstance(arr, xr.DataArray):
+        raise TypeError('Expected arr to be instance of xr.DataArray')
     flip_axes: set[str] = set()
     for d in arr.dims:
         c = arr.coords[d]

--- a/src/arpes/utilities/conversion/kx_ky_conversion.py
+++ b/src/arpes/utilities/conversion/kx_ky_conversion.py
@@ -236,8 +236,10 @@ class ConvertKp(CoordinateConverter):
             self.compute_k_tot(binding_energy)
         self.phi = np.zeros_like(kp)
         par_tot = isinstance(self.k_tot, np.ndarray) and len(self.k_tot) != 1
-        assert self.k_tot is not None
-        assert len(self.k_tot) == len(kp) or len(self.k_tot) == 1
+        if not (self.k_tot is not None):
+            raise ValueError('Assertion failed: self.k_tot is not None')
+        if not (len(self.k_tot) == len(kp) or len(self.k_tot) == 1):
+            raise ValueError('Assertion failed: len(self.k_tot) == len(kp) or len(self.k_tot) == 1')
         _small_angle_arcsin(
             kp / np.cos(polar_angle),
             self.k_tot,
@@ -248,7 +250,8 @@ class ConvertKp(CoordinateConverter):
         )
         if isinstance(self.calibration, DetectorCalibration):
             self.phi = self.calibration.correct_detector_angle(eV=binding_energy, phi=self.phi)
-        assert self.phi is not None
+        if not (self.phi is not None):
+            raise ValueError('Assertion failed: self.phi is not None')
         return self.phi
 
     def conversion_for(
@@ -295,7 +298,8 @@ class ConvertKxKy(CoordinateConverter):
         self.direct_angles = ("phi", next(d for d in ["psi", "beta", "theta"] if d in arr.indexes))
         if self.direct_angles[1] != "psi":
             # psi allows for either orientation
-            assert (self.direct_angles[1] == "theta") != (not self.is_slit_vertical)
+            if not ((self.direct_angles[1] == "theta") != (not self.is_slit_vertical)):
+                raise ValueError('Assertion failed: (self.direct_angles[1] == "theta") != (not self.is_slit_vertical)')
         # determine which other angles constitute equivalent sets
         opposite_direct_angle = "theta" if "psi" in self.direct_angles else "psi"
         if self.is_slit_vertical:
@@ -445,8 +449,10 @@ class ConvertKxKy(CoordinateConverter):
         self.phi = np.zeros_like(ky)
         offset = self.arr.S.phi_offset + self.arr.S.lookup_offset_coord(self.parallel_angles[0])
         par_tot = isinstance(self.k_tot, np.ndarray) and len(self.k_tot) != 1
-        assert self.k_tot is not None
-        assert len(self.k_tot) == len(self.phi) or len(self.k_tot) == 1
+        if not (self.k_tot is not None):
+            raise ValueError('Assertion failed: self.k_tot is not None')
+        if not (len(self.k_tot) == len(self.phi) or len(self.k_tot) == 1):
+            raise ValueError('Assertion failed: len(self.k_tot) == len(self.phi) or len(self.k_tot) == 1')
         if scan_angle == "psi":
             if self.is_slit_vertical:
                 _exact_arcsin(ky, kx, self.k_tot, self.phi, offset, par_tot=par_tot, negate=False)
@@ -483,8 +489,10 @@ class ConvertKxKy(CoordinateConverter):
         scan_angle = self.direct_angles[1]
         self.perp_angle = np.zeros_like(kx)
         par_tot = isinstance(self.k_tot, np.ndarray) and len(self.k_tot) != 1
-        assert self.k_tot is not None
-        assert len(self.k_tot) == len(self.perp_angle) or len(self.k_tot) == 1
+        if not (self.k_tot is not None):
+            raise ValueError('Assertion failed: self.k_tot is not None')
+        if not (len(self.k_tot) == len(self.perp_angle) or len(self.k_tot) == 1):
+            raise ValueError('Assertion failed: len(self.k_tot) == len(self.perp_angle) or len(self.k_tot) == 1')
         if scan_angle == "psi":
             if self.is_slit_vertical:
                 offset = self.arr.S.psi_offset - self.arr.S.lookup_offset_coord(

--- a/src/arpes/utilities/conversion/kz_conversion.py
+++ b/src/arpes/utilities/conversion/kz_conversion.py
@@ -95,7 +95,8 @@ class ConvertKpKz(CoordinateConverter):
             Thus the keys are "kp", "kx", and "eV", but not "phi"
         """
         resolution = resolution if resolution is not None else {}
-        assert resolution is not None
+        if not (resolution is not None):
+            raise ValueError('Assertion failed: resolution is not None')
         bounds = bounds if bounds is not None else {}
 
         coordinates = {k: v.values for k, v in self.arr.coords.items() if k == "eV"}
@@ -176,7 +177,8 @@ class ConvertKpKz(CoordinateConverter):
             return self.phi
         if self.hv is None:
             self.kspace_to_hv(binding_energy, kp, kz)
-        assert self.hv is not None
+        if not (self.hv is not None):
+            raise ValueError('Assertion failed: self.hv is not None')
         if self.arr.S.energy_notation is EnergyNotation.BINDING:
             kinetic_energy = binding_energy + self.hv - self.arr.S.analyzer_work_function
         else:  # self.arr.S.energy_notation is EnergyNotation.FINAL:

--- a/src/arpes/utilities/funcutils.py
+++ b/src/arpes/utilities/funcutils.py
@@ -95,7 +95,8 @@ def lift_dataarray_to_generic(
     def func_wrapper(data: DataType, *args: P.args, **kwargs: P.kwargs) -> DataType:
         if isinstance(data, xr.DataArray):
             return func(data, *args, **kwargs)
-        assert isinstance(data, xr.Dataset)
+        if not isinstance(data, xr.Dataset):
+            raise TypeError('Expected data to be instance of xr.Dataset')
         new_vars = {datavar: func(data[datavar], *args, **kwargs) for datavar in data.data_vars}
 
         for var_name, var in new_vars.items():

--- a/src/arpes/utilities/normalize.py
+++ b/src/arpes/utilities/normalize.py
@@ -37,8 +37,10 @@ def normalize_to_spectrum(data: DataWithCoords) -> xr.DataArray:
             stacklevel=2,
         )
         if "up" in data.data_vars:
-            assert isinstance(data.up, xr.DataArray)
+            if not isinstance(data.up, xr.DataArray):
+                raise TypeError("Dataset 'up' variable is not an xarray.DataArray")
             return data.up
         return data.S.spectrum
-    assert isinstance(data, xr.DataArray)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError("data must be an xarray.DataArray")
     return data

--- a/src/arpes/utilities/region.py
+++ b/src/arpes/utilities/region.py
@@ -194,7 +194,8 @@ def region_sel(
         }
 
         options_for_dim = options.get(dimension_name, list(DesignatedRegions))
-        assert selector in options_for_dim
+        if not (selector in options_for_dim):
+            raise ValueError('Assertion failed: selector in options_for_dim')
 
         # now we need to resolve out the region
         resolution_methods = {

--- a/src/arpes/utilities/selections.py
+++ b/src/arpes/utilities/selections.py
@@ -86,7 +86,8 @@ def fat_sel(
     logger.debug(f"kwargs: {kwargs}")
     if widths is None:
         widths = {}
-    assert isinstance(widths, dict)
+    if not isinstance(widths, dict):
+        raise TypeError('Expected widths to be instance of dict')
     default_widths = DEFAULT_RADII
 
     if data.S.angle_unit is AngleUnit.DEG:
@@ -158,16 +159,20 @@ def select_around_data(
     Returns:
         The binned selection around the desired point or points.
     """
-    assert mode in {"sum", "mean"}, "mode parameter should be either sum or mean."
-    assert isinstance(points, dict | xr.Dataset)
+    if not (mode in {"sum", "mean"}):
+        raise ValueError('mode parameter should be either sum or mean.')
+    if not isinstance(points, dict | xr.Dataset):
+        raise TypeError('Expected points to be instance of dict | xr.Dataset')
     radius = radius or {}
     if isinstance(points, xr.Dataset):
         points = {k: points[k].item() for k in points.data_vars}
-    assert isinstance(points, dict)
+    if not isinstance(points, dict):
+        raise TypeError('Expected points to be instance of dict')
     radius = _radius(points, radius)
     logger.debug(f"radius: {radius}")
 
-    assert isinstance(radius, dict)
+    if not isinstance(radius, dict):
+        raise TypeError('Expected radius to be instance of dict')
     logger.debug(f"iter(points.values()): {iter(points.values())}")
 
     along_dims = next(iter(points.values())).dims
@@ -230,8 +235,10 @@ def select_around(
     Returns:
         The binned selection around the desired point.
     """
-    assert mode in {"sum", "mean"}, "mode parameter should be either sum or mean."
-    assert isinstance(point, dict | xr.Dataset)
+    if not (mode in {"sum", "mean"}):
+        raise ValueError('mode parameter should be either sum or mean.')
+    if not isinstance(point, dict | xr.Dataset):
+        raise TypeError('Expected point to be instance of dict | xr.Dataset')
     radius = _radius(point, radius)
     stride = data.G.stride(generic_dim_names=False)
     nearest_sel_params: dict[Hashable, float] = {}
@@ -339,7 +346,8 @@ def select_disk_mask(
     data_array = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
 
     raveled = data_array.G.ravel()
-    assert around is not None
+    if not (around is not None):
+        raise ValueError('Assertion failed: around is not None')
 
     dim_order = list(around.keys())
     dist = np.sqrt(
@@ -385,7 +393,8 @@ def select_disk(
     """
     data_array = data if isinstance(data, xr.DataArray) else normalize_to_spectrum(data)
     mask = select_disk_mask(data_array, radius, outer_radius=outer_radius, around=around, flat=True)
-    assert around is not None
+    if not (around is not None):
+        raise ValueError('Assertion failed: around is not None')
 
     if invert:
         mask = np.logical_not(mask)

--- a/src/arpes/workflow.py
+++ b/src/arpes/workflow.py
@@ -146,7 +146,8 @@ def go_to_workspace(workspace: WorkSpaceType | None = None) -> None:
     workspace = workspace or config_manager.config["WORKSPACE"]
 
     if workspace:
-        assert "path" in workspace
+        if not ("path" in workspace):
+            raise ValueError('Assertion failed: "path" in workspace')
         path = Path(workspace["path"])
 
     _open_path(path)
@@ -202,7 +203,8 @@ class DataProvider:
 
     @publishers.setter
     def publishers(self, new_publishers: dict[str, object]) -> None:
-        assert isinstance(new_publishers, dict)
+        if not isinstance(new_publishers, dict):
+            raise TypeError('Expected new_publishers to be instance of dict')
         self._write_pickled("publishers", new_publishers)
 
     @property
@@ -211,7 +213,8 @@ class DataProvider:
 
     @consumers.setter
     def consumers(self, new_consumers: dict[str, object]) -> None:
-        assert isinstance(new_consumers, dict)
+        if not isinstance(new_consumers, dict):
+            raise TypeError('Expected new_consumers to be instance of dict')
         self._write_pickled("consumers", new_consumers)
 
     def __init__(self, path: Path, workspace_name: str | None = None) -> None:
@@ -266,7 +269,8 @@ class DataProvider:
         workspace: WorkSpaceType | None = None,
     ) -> DataProvider:
         if workspace is not None:
-            assert "path" in workspace
+            if not ("path" in workspace):
+                raise ValueError('Assertion failed: "path" in workspace')
             return cls(
                 path=Path(workspace["path"]),
                 workspace_name=workspace.get("name", "no_name"),

--- a/src/arpes/xarray_extensions/_helper/general.py
+++ b/src/arpes/xarray_extensions/_helper/general.py
@@ -32,7 +32,8 @@ def round_coordinates_impl(
 
     Assumes `data` is a concrete xarray object (DataArray or Dataset).
     """
-    assert isinstance(data, xr.DataArray | xr.Dataset)
+    if not isinstance(data, xr.DataArray | xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.DataArray | xr.Dataset')
     rounded = {
         k: v.item()
         for k, v in data.sel(coords_to_round, method="nearest").coords.items()
@@ -114,7 +115,8 @@ def apply_over_impl(
 
     Assumes `data` is a concrete xarray object (DataArray or Dataset).
     """
-    assert isinstance(data, xr.DataArray | xr.Dataset)
+    if not isinstance(data, xr.DataArray | xr.Dataset):
+        raise TypeError('Expected data to be instance of xr.DataArray | xr.Dataset')
 
     data = data.copy(deep=True) if copy else data
 

--- a/src/arpes/xarray_extensions/_helper/misc.py
+++ b/src/arpes/xarray_extensions/_helper/misc.py
@@ -49,5 +49,6 @@ def safe_error(model_result_instance: ModelResult | None) -> float:
     """
     if model_result_instance is None:
         return np.nan
-    assert isinstance(model_result_instance.residual, np.ndarray)
+    if not isinstance(model_result_instance.residual, np.ndarray):
+        raise TypeError('Expected model_result_instance.residual to be instance of np.ndarray')
     return (model_result_instance.residual**2).mean()

--- a/src/arpes/xarray_extensions/_helper/spectroscopy.py
+++ b/src/arpes/xarray_extensions/_helper/spectroscopy.py
@@ -37,7 +37,8 @@ def sum_other_impl(
 
     Assumes `data` is a concrete xarray object (DataArray or Dataset).
     """
-    assert isinstance(dim_or_dims, list)
+    if not isinstance(dim_or_dims, list):
+        raise TypeError('Expected dim_or_dims to be instance of list')
 
     return data.sum(
         [d for d in data.dims if d not in dim_or_dims],
@@ -73,7 +74,8 @@ def mean_other_impl(
 
     Assumes `data` is a concrete xarray object (DataArray or Dataset).
     """
-    assert isinstance(dim_or_dims, list)
+    if not isinstance(dim_or_dims, list):
+        raise TypeError('Expected dim_or_dims to be instance of list')
 
     return data.mean(
         [d for d in data.dims if d not in dim_or_dims],

--- a/src/arpes/xarray_extensions/accessor/base.py
+++ b/src/arpes/xarray_extensions/accessor/base.py
@@ -142,7 +142,8 @@ class ARPESDataArrayAccessorBase(ARPESAccessorBase[xr.DataArray]):
         Returns (bool):
             Return True if the data is subtracted.
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         if self._obj.attrs.get("subtracted"):
             return True
 
@@ -252,8 +253,10 @@ class GenericAccessorBase(Generic[DataType]):
             category=DeprecationWarning,
             stacklevel=2,
         )
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
-        assert len(self._obj.dims) == 1
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
+        if not (len(self._obj.dims) == 1):
+            raise ValueError('Assertion failed: len(self._obj.dims) == 1')
 
         dim = self._obj.dims[0]
         if as_coordinate_name is None:
@@ -278,7 +281,8 @@ class GenericAccessorBase(Generic[DataType]):
             ((0, 0), {'phi': -0.2178031280148764, 'eV': 9.0})
             which shows the relationship between pixel position and physical (like "eV" and "phi").
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         dim_names = dim_names or tuple(self._obj.dims)
         dim_names = [dim_names] if isinstance(dim_names, str) else dim_names
         coords_list = [self._obj.coords[d].values for d in dim_names]

--- a/src/arpes/xarray_extensions/accessor/fit.py
+++ b/src/arpes/xarray_extensions/accessor/fit.py
@@ -104,7 +104,8 @@ class ARPESDatasetFitToolAccessor:
             stacklevel=2,
         )
 
-        assert isinstance(self._obj, xr.Dataset)
+        if not isinstance(self._obj, xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.Dataset')
         if any(str(i).startswith("modelfit_best_fit") for i in self._obj.data_vars):
             return list(
                 set(self._obj["modelfit_data"].dims).difference(
@@ -197,7 +198,8 @@ class ARPESFitToolsAccessor:
         Producing a scalar metric of the error for all model result instances in
         the collection.
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
 
         return self._obj.G.map(safe_error)
 
@@ -217,7 +219,8 @@ class ARPESFitToolsAccessor:
         Todo:
             Test
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         stacked = self._obj.stack(dim={"by_error": self._obj.dims})
 
         error = stacked.F.mean_square_error()
@@ -246,7 +249,8 @@ class ARPESFitToolsAccessor:
         Memo:
             Work after xarray-lmfit migration.
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         return self._obj.G.map(param_getter(param_name), otypes=[float])
 
     def s(self, param_name: str) -> xr.DataArray:
@@ -267,7 +271,8 @@ class ARPESFitToolsAccessor:
         Memo:
             Work after xarray-lmfit migration.
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         return self._obj.G.map(param_stderr_getter(param_name), otypes=[float])
 
     @property
@@ -300,7 +305,8 @@ class ARPESFitToolsAccessor:
             would contain `"a_"`.
         """
         collected_band_names: set[str] = set()
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         for item in self._obj.values.ravel():
             if item is None:
                 continue
@@ -326,7 +332,8 @@ class ARPESFitToolsAccessor:
             Work after xarray-lmfit migration.
         """
         collected_parameter_names: set[str] = set()
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         for item in self._obj.values.ravel():
             if item is None:
                 continue

--- a/src/arpes/xarray_extensions/accessor/general.py
+++ b/src/arpes/xarray_extensions/accessor/general.py
@@ -73,7 +73,8 @@ class GenericDatasetAccessor(GenericAccessorBase[xr.Dataset]):
             to be accessed via the `.G` property of an `xarray.Dataset` object.
         """
         self._obj = xarray_obj
-        assert isinstance(self._obj, xr.Dataset)
+        if not isinstance(self._obj, xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.Dataset')
 
     def filter_vars(
         self,
@@ -122,7 +123,8 @@ class GenericDatasetAccessor(GenericAccessorBase[xr.Dataset]):
         See Also:
             :py:meth:`xarray.Dataset.drop_vars`: To explicitly remove variables by name.
         """
-        assert isinstance(self._obj, xr.Dataset)  # ._obj.data_vars
+        if not isinstance(self._obj, xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.Dataset')
         return xr.Dataset(
             data_vars={k: v for k, v in self._obj.data_vars.items() if f(k, v)},
             attrs=self._obj.attrs,
@@ -162,7 +164,8 @@ class GenericDatasetAccessor(GenericAccessorBase[xr.Dataset]):
         shift_array = np.ones((len(dims),)) * shift if isinstance(shift, float) else shift
 
         def transform(data: NDArray[np.floating]) -> NDArray[np.floating]:
-            assert isinstance(shift_array, np.ndarray)
+            if not isinstance(shift_array, np.ndarray):
+                raise TypeError('Expected shift_array to be instance of np.ndarray')
             new_shift: NDArray[np.floating] = shift_array
             for _ in range(len(dims)):
                 new_shift = np.expand_dims(new_shift, axis=0)
@@ -253,7 +256,8 @@ class GenericDatasetAccessor(GenericAccessorBase[xr.Dataset]):
             ValueError: If the `transform` callable does not return an array
                 of the expected shape.
         """  # noqa: E501
-        assert isinstance(self._obj, xr.Dataset)
+        if not isinstance(self._obj, xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.Dataset')
         as_ndarray = np.stack([self._obj.data_vars[d].values for d in dims], axis=-1)
 
         if isinstance(transform, np.ndarray):
@@ -397,13 +401,15 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
             to be accessed via the `.G` property of an `xarray.DataArray` object.
         """
         self._obj: xr.DataArray = xarray_obj
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
 
     def argmax_coords(self) -> dict[Hashable, float]:
         """Return dict representing the position for maximum value."""
         data: xr.DataArray = self._obj
         raveled = data.argmax(None)
-        assert isinstance(raveled, xr.DataArray)
+        if not isinstance(raveled, xr.DataArray):
+            raise TypeError('Expected raveled to be instance of xr.DataArray')
         idx = raveled.item()
         flat_indices = np.unravel_index(idx, data.values.shape)
         return {d: data.coords[d][flat_indices[i]].item() for i, d in enumerate(data.dims)}
@@ -420,7 +426,8 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
             A dictionary mapping between coordinate names and their coordinate arrays.
             Additionally, there is a key "data" which maps to the `.values` attribute of the array.
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
 
         dims = self._obj.dims
         coords_as_list = [self._obj.coords[d].values for d in dims]
@@ -431,7 +438,8 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
                 strict=True,
             ),
         )
-        assert "data" not in raveled_coordinates
+        if not ("data" not in raveled_coordinates):
+            raise ValueError('Assertion failed: "data" not in raveled_coordinates')
         raveled_coordinates["data"] = self._obj.values.ravel()
 
         return raveled_coordinates
@@ -510,12 +518,14 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
             `numpy.meshgrid`: The core NumPy function for creating coordinate grids.
             `~.GenericDataArrayAccessor.ravel`: For flattening the data and coordinates.
         """
-        assert isinstance(self._obj, xr.DataArray)  # ._obj.values is used.
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
 
         dims = self._obj.dims
         coords_as_list = [self._obj.coords[d].values for d in dims]
         meshed_coordinates = dict(zip(dims, list(np.meshgrid(*coords_as_list)), strict=True))
-        assert "data" not in meshed_coordinates
+        if not ("data" not in meshed_coordinates):
+            raise ValueError('Assertion failed: "data" not in meshed_coordinates')
         meshed_coordinates["data"] = self._obj.values
 
         if as_dataset:
@@ -557,7 +567,8 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
         Todo:
             - Add unit tests to ensure the method behaves as expected.
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         low, high = np.percentile(self._obj.values, [clip, 100 - clip])
         copied = self._obj.copy(deep=True)
         copied.values[copied.values < low] = low
@@ -611,7 +622,8 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
             # Generate an animation
             animation = data.G.as_movie(time_dim="delay")
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
 
         return plot_movie(self._obj, time_dim=time_dim, out=out, **kwargs)
 
@@ -763,7 +775,8 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
                 )
 
             dest.loc[coord] = new_value
-        assert isinstance(dest, xr.DataArray)
+        if not isinstance(dest, xr.DataArray):
+            raise TypeError('Expected dest to be instance of xr.DataArray')
         return dest
 
     def map(
@@ -862,7 +875,8 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
 
         ToDo: Test
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         if keep_attrs:
             return xr.DataArray(
                 data=new_values.reshape(self._obj.values.shape),

--- a/src/arpes/xarray_extensions/accessor/property.py
+++ b/src/arpes/xarray_extensions/accessor/property.py
@@ -170,7 +170,8 @@ class ARPESPhysicalProperty(Generic[DataType]):
         Note:
             This "work_function" should *NOT* be used for k-conversion!
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         if "sample_workfunction" in self._obj.attrs:
             return self._obj.attrs["sample_workfunction"]
         return 4.3
@@ -184,7 +185,8 @@ class ARPESPhysicalProperty(Generic[DataType]):
         Note:
             Use this value for k-conversion.
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         if "workfunction" in self._obj.attrs:
             return self._obj.attrs["workfunction"]
         return 4.401
@@ -192,7 +194,8 @@ class ARPESPhysicalProperty(Generic[DataType]):
     @property
     def inner_potential(self) -> float:
         """The inner potential, if present in metadata. Otherwise, 10 eV is assumed."""
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         if "inner_potential" in self._obj.attrs:
             return self._obj.attrs["inner_potential"]
         return 10
@@ -223,7 +226,8 @@ class ARPESPhysicalProperty(Generic[DataType]):
         Returns: float | xr.DataArray
             Photon energy in eV unit.  (for hv_map type, xr.DataArray is returned.)
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         try:
             return float(self._obj.coords["hv"])
         except TypeError:
@@ -615,7 +619,8 @@ class ARPESInfoProperty(ARPESPhysicalProperty[DataType]):
     @property
     def spectrum_type(self) -> SpectrumType:
         """Spectrum type (cut, map, hv_map, ucut, spem and xps)."""
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
 
         raw = self._obj.attrs.get("spectrum_type")
         if isinstance(raw, SpectrumType):
@@ -695,7 +700,8 @@ class ARPESOffsetProperty(ARPESAngleProperty[DataType]):
                     * coords["physical_long_x"] seems to be just x_offset.
 
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         if "long_x" not in self._obj.coords:
             msg = "Logical offsets can currently only be accessed for hierarchical"
             msg += " motor systems like nanoARPES."
@@ -724,7 +730,8 @@ class ARPESOffsetProperty(ARPESAngleProperty[DataType]):
     def lookup_offset(self, attr_name: str) -> float:
         """Return the offset value."""
         symmetry_points = self.symmetry_points()
-        assert isinstance(symmetry_points, dict)
+        if not isinstance(symmetry_points, dict):
+            raise TypeError('Expected symmetry_points to be instance of dict')
         if "G" in symmetry_points:
             gamma_point = symmetry_points["G"]  # {"phi": 0.405}  (cut)
             if attr_name in gamma_point:
@@ -810,7 +817,8 @@ class ARPESOffsetProperty(ARPESAngleProperty[DataType]):
             >>> ds.attrs['theta_offset']
             -0.1
         """
-        assert isinstance(self._obj, xr.Dataset | xr.DataArray)
+        if not isinstance(self._obj, xr.Dataset | xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.Dataset | xr.DataArray')
         for k, v in offsets.items():
             self._obj.attrs[f"{k}_offset"] = v
 
@@ -964,7 +972,8 @@ class ARPESProvenanceProperty(Generic[DataType]):
         """Return id object of the parent object."""
         if not self.history:
             return None
-        assert self.history is not None
+        if not (self.history is not None):
+            raise ValueError('Assertion failed: self.history is not None')
         for a_history in reversed(self.history):
             if "parent_id" in a_history:
                 return a_history["parent_id"]
@@ -986,7 +995,8 @@ class ARPESPropertyBase(
             True if the data is explicitly a "ucut" or "spem" or contains "X", "Y", or "Z"
             dimensions. False otherwise.
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
 
         if self.spectrum_type.is_intrinsically_spatial:
             return True
@@ -1003,7 +1013,8 @@ class ARPESPropertyBase(
         Returns:
             True if the data is k-space converted. False otherwise.
         """
-        assert isinstance(self._obj, xr.DataArray | xr.Dataset)
+        if not isinstance(self._obj, xr.DataArray | xr.Dataset):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray | xr.Dataset')
         return not any(d in {"phi", "theta", "beta", "angle"} for d in self._obj.dims)
 
     @property
@@ -1176,7 +1187,8 @@ class ARPESProperty(ARPESPropertyBase[DataType]):
             transformed_dict: dict[str, str] = {}
             for k, v in conditions.items():
                 if k == "polarrization":
-                    assert isinstance(v, (float | str))
+                    if not isinstance(v, float | str):
+                        raise TypeError('Expected v to be instance of float | str')
                     transformed_dict[k] = {
                         "p": "Linear Horizontal",
                         "s": "Linear Vertical",

--- a/src/arpes/xarray_extensions/accessor/spectroscopy.py
+++ b/src/arpes/xarray_extensions/accessor/spectroscopy.py
@@ -61,7 +61,8 @@ class ARPESDataArrayAccessor(ARPESDataArrayAccessorBase):
     def __init__(self, xarray_obj: xr.DataArray) -> None:
         """Initialize."""
         self._obj: xr.DataArray = xarray_obj
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
 
     def corrected_coords(
         self,
@@ -148,7 +149,8 @@ class ARPESDataArrayAccessor(ARPESDataArrayAccessorBase):
         **kwargs: Unpack[LabeledFermiSurfaceParam],
     ) -> Path | tuple[Figure | None, Axes]:
         """Provides a reference plot of the approximate Fermi surface."""
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         out = kwargs.get("out")
         if out is not None and isinstance(out, bool):
             out = pattern.format(f"{self.label}_fs")
@@ -183,7 +185,8 @@ class ARPESDataArrayAccessor(ARPESDataArrayAccessorBase):
             the plot.Provides a reference plot for a Fermi edge reference.
 
         """
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         if out is not None and isinstance(out, bool):
             out = pattern.format(f"{self.label}_fermi_edge_reference")
         return fermi_edge_reference(self._obj, out=out, **kwargs)
@@ -264,7 +267,8 @@ class ARPESDataArrayAccessor(ARPESDataArrayAccessorBase):
         out: str | Path = "",
         **kwargs: Unpack[PColorMeshKwargs],
     ) -> Axes | Path:
-        assert isinstance(self._obj, xr.DataArray)
+        if not isinstance(self._obj, xr.DataArray):
+            raise TypeError('Expected self._obj to be instance of xr.DataArray')
         label = self._obj.attrs["id"] if use_id else self.label
         if isinstance(out, bool):
             out = pattern.format(f"{label}_spectrum_reference")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,10 @@ from arpes.io import example_data
 from tests.utils import cache_loader
 from arpes.preparation import normalize_dim
 
+# Ensure package initialization (registers xarray accessors like .S and .G)
+from arpes.configuration.interface import get_config_manager  # noqa: E402
+get_config_manager().initialize()
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 

--- a/tests/test_analysis_background.py
+++ b/tests/test_analysis_background.py
@@ -48,5 +48,5 @@ def test_remove_background_hull_linear(lorentzian_linear_bg: xr.DataArray):
 
 
 def test_invalid_input():
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         calculate_background_hull(np.array([1, 2, 3]))

--- a/tests/test_correction_intensity_map.py
+++ b/tests/test_correction_intensity_map.py
@@ -79,7 +79,7 @@ def test_shift_extend_coords_max(sample_data: xr.DataArray):
 
 def test_shift_axis_required(sample_data: xr.DataArray):
     shift_vals = np.ones(sample_data.sizes["y"])
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         shift(sample_data, shift_vals, shift_axis="")
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -63,7 +63,7 @@ def test_load_and_save_pickle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.skip
 def test_stitch_invalid_input():
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         io._df_or_list_to_files("not a list")
 
 

--- a/tests/test_plotting_basic.py
+++ b/tests/test_plotting_basic.py
@@ -33,10 +33,10 @@ def test_make_overview_valid_input() -> None:
 @pytest.mark.skip
 def test_make_overview_invalid_input() -> None:
     # data_allがSequenceではない場合
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         make_overview(None)  # type: ignore[arg-type]
 
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         make_overview({})  # type: ignore[arg-type]
 
 

--- a/tests/test_plotting_decoration.py
+++ b/tests/test_plotting_decoration.py
@@ -155,12 +155,12 @@ def test_v_gradient_fill_with_default_ax(monkeypatch):
 def test_h_gradient_fill_invalid_range():
     fig, ax = plt.subplots()
 
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         h_gradient_fill(3.0, 1.0, None, fill_color="blue", ax=ax)
 
 
 def test_v_gradient_fill_invalid_range():
     fig, ax = plt.subplots()
 
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         v_gradient_fill(5.0, 2.0, None, fill_color="red", ax=ax)

--- a/tests/test_plotting_stack_plot.py
+++ b/tests/test_plotting_stack_plot.py
@@ -53,7 +53,7 @@ def test_returns_two_axes_when_scale_zero(test_data):
 
 
 def test_negative_scale_factor_raises(test_data):
-    with pytest.raises(AssertionError, match="scale factor should be positive"):
+    with pytest.raises((AssertionError, TypeError, ValueError), match="scale factor should be positive"):
         waterfall_dispersion(test_data, scale_factor=-1)
 
 

--- a/tests/test_plotting_ui_smooth.py
+++ b/tests/test_plotting_ui_smooth.py
@@ -162,7 +162,7 @@ class TestSmoothingApp:
 
     def test_init_raises_assertion_for_high_dim_data(self):
         high_dim_data = xr.DataArray([[[[1, 2], [3, 4]]]], dims=["a", "b", "c", "d"])
-        with pytest.raises(AssertionError):
+        with pytest.raises((AssertionError, TypeError, ValueError)):
             SmoothingApp(high_dim_data)
 
     def test_smoothing_func_selection_updates_widgets(self, sample_data_1d):

--- a/tests/test_preparation_axis.py
+++ b/tests/test_preparation_axis.py
@@ -174,7 +174,7 @@ def test_vstack_data_missing_new_dim_in_both():
     data1 = xr.DataArray([1, 2, 3], dims=["phi"])
     data2 = xr.DataArray([4, 5, 6], dims=["phi"])
 
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         vstack_data([data1, data2], "new_dim")
 
 

--- a/tests/test_tarpes.py
+++ b/tests/test_tarpes.py
@@ -267,6 +267,71 @@ def test_plot_movie_and_evolution_with_labels(another_sample_data: xr.DataArray)
     assert ax[1].get_xlabel() == labels[1]
 
 
+def test_output_animation_requires_update_func_and_fig(sample_data: xr.DataArray):
+    """output_animation should raise ValueError when update_func or fig are missing for non-path outputs."""
+    from arpes.plotting.movie import output_animation
+
+    with pytest.raises(ValueError, match="Both 'update_func' and 'fig' must be provided"):
+        # out=0 triggers the numeric snapshot branch after validation; update_func/fig are intentionally None
+        output_animation(anim=None, data=sample_data, update_func=None, fig=None, time_dim="delay", out=0)
+
+
+def test_initialize_figure_and_axes_invalid_ax():
+    """_initialize_figure_and_axes should raise when ax is None or too short."""
+    from arpes.plotting.movie import _initialize_figure_and_axes
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+    # ax is None -> RuntimeError
+    with pytest.raises(RuntimeError):
+        _initialize_figure_and_axes((fig, None), figsize=(9.0, 5.0), width_ratio=(1.0, 4.4))
+
+    # ax is list of length 1 -> TypeError about expecting two Axes
+    with pytest.raises(TypeError, match="Expected 'ax' to be an array-like with two Axes"):
+        _initialize_figure_and_axes((fig, [object()]), figsize=(9.0, 5.0), width_ratio=(1.0, 4.4))
+
+
+def test_plot_movie_invalid_ndim(another_sample_data: xr.DataArray):
+    """plot_movie should raise ValueError if data.ndim is not 3."""
+    from arpes.plotting.movie import plot_movie
+
+    # Create 2D data (missing time dimension)
+    two_d = another_sample_data.isel(delay=0).squeeze()
+    with pytest.raises(ValueError, match="Expected data with ndim"):
+        plot_movie(two_d, out=None)
+
+
+def test_plot_movie_and_evolution_invalid_ndim(another_sample_data: xr.DataArray):
+    """plot_movie_and_evolution should raise ValueError if data.ndim is not 3."""
+    from arpes.plotting.movie import plot_movie_and_evolution
+
+    two_d = another_sample_data.isel(delay=0).squeeze()
+    with pytest.raises(ValueError, match="Expected data with ndim"):
+        plot_movie_and_evolution(two_d, out=None)
+
+
+def test_plot_movie_invalid_ax_type(another_sample_data: xr.DataArray):
+    """plot_movie should raise TypeError when an invalid ax is provided in fig_ax."""
+    from arpes.plotting.movie import plot_movie
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+    bad_ax = object()
+    with pytest.raises(TypeError, match="ax must be a matplotlib.axes.Axes instance"):
+        plot_movie(another_sample_data, fig_ax=(fig, bad_ax), out=None)
+
+
+def test_initialize_figure_and_axes_fig_type_error():
+    """_initialize_figure_and_axes should raise TypeError when fig is not a Figure."""
+    from arpes.plotting.movie import _initialize_figure_and_axes
+
+    import matplotlib.pyplot as plt
+    fig_real, axes = plt.subplots(nrows=1, ncols=2)
+    bad_fig = object()
+    with pytest.raises(TypeError, match="fig is not a matplotlib.figure.Figure"):
+        _initialize_figure_and_axes((bad_fig, axes), figsize=(9.0, 5.0), width_ratio=(1.0, 4.4))
+
+
 def test_plot_movie_and_evolution_is_subtracted_true(another_sample_data: xr.DataArray):
     """Test when data.S.is_subtracted is True."""
     another_sample_data.attrs["subtracted"] = True
@@ -315,3 +380,20 @@ def test_plot_movie_and_evolution_is_subtracted_true_with_labels(another_sample_
     # Verify that the labels are correctly applied
     assert ax[0].get_xlabel() == labels[0]
     assert ax[0].get_ylabel() == labels[1]
+
+
+def test_plot_movie_fig_and_data_type_checks(another_sample_data: xr.DataArray):
+    """plot_movie should raise TypeError for invalid fig and data types."""
+    from arpes.plotting.movie import plot_movie
+    import matplotlib.pyplot as plt
+
+    fig_real, ax_real = plt.subplots()
+    bad_fig = object()
+    # bad fig
+    with pytest.raises(TypeError, match="fig must be a matplotlib.figure.Figure instance"):
+        plot_movie(another_sample_data, fig_ax=(bad_fig, ax_real), out=None)
+
+    # bad data
+    bad_data = object()
+    with pytest.raises(TypeError, match="data must be an xarray.DataArray"):
+        plot_movie(bad_data, fig_ax=(fig_real, ax_real), out=None)

--- a/tests/test_utilities_combine.py
+++ b/tests/test_utilities_combine.py
@@ -76,7 +76,7 @@ def test_concat_same_phi_min_raises(mock_dataarrays):
 def test_invalid_occupation_ratio(mock_dataarrays):
     """Test assertion error when occupation_ratio is outside [0, 1]."""
     arr_a, arr_b = mock_dataarrays
-    with pytest.raises(AssertionError):
+    with pytest.raises((AssertionError, TypeError, ValueError)):
         concat_along_phi(arr_a, arr_b, occupation_ratio=1.5)
 
 


### PR DESCRIPTION
Convert public-facing assert checks to explicit TypeError/ValueError for consistent API behavior. Tests updated; full suite passes locally.