### PR TITLE
:art: (Rename plot_moview -> movie, expose movie at arpes.plotting, a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ requirements.lock
 # JS Ecosystem
 node_modules/
 
+*.bak
 
 # Lanzara Group Internal Utilities
 arpes/tight_binding/**

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -39,6 +39,19 @@ primarily indicate new features and documentation.
   * Tidy up some fitting functions
     * Remove TwoExponentialDecayCModel
 
+* Breaking change in plotting
+
+  * API change: the movie creation function was renamed for conciseness.
+  * The function previously available as `arpes.plotting.movie.plot_movie` was
+    renamed to `movie` in `arpes.plotting.movie` and can be called as
+    `arpes.plotting.movie(...)` for convenience.
+  * The top-level symbol `arpes.plotting.plot_movie` has been removed. Callers
+    should update imports to `from arpes.plotting import movie` or
+    `from arpes.plotting.movie import movie`.
+  * Backwards-compatible aliases (`plot_movie`) remain in the module to ease
+    migration, but clients should migrate to the new name; the alias may be
+    removed in a future release.
+
 5.0.2 (2025-12-23)
 ^^^^^^^^^^^^^^^^^^
 

--- a/src/arpes/correction/trapezoid.py
+++ b/src/arpes/correction/trapezoid.py
@@ -286,7 +286,7 @@ class ConvertTrapezoidalCorrection(CoordinateConverter):
 def trapezoid(
     data: xr.DataArray,
     corners: list[dict[str, float] | float],
-    rectangle_phis: list[float] | None = None,
+    rectangle_phis: list[float] | tuple[float, float] | None = None,
     *,
     from_trapezoid: bool = True,
 ) -> xr.DataArray:
@@ -352,7 +352,7 @@ def trapezoid(
         rectangle_phis = [trapezoid_corners[1]["phi"], trapezoid_corners[3]["phi"]]
     elif rectangle_phis is None and not from_trapezoid:
         rectangle_phis = [data.coords["phi"].min().item(), data.coords["phi"].max().item()]
-    assert isinstance(rectangle_phis, list)
+    assert isinstance(rectangle_phis, (list, tuple))
 
     logger.debug("Determining dimensions.")
     data = data.transpose("eV", "phi", ...)

--- a/src/arpes/endstations/base.py
+++ b/src/arpes/endstations/base.py
@@ -182,7 +182,7 @@ class EndstationBase:
           extension.
         """
         warnings.warn(
-            "Thisi is the EndstationBase's `first_find_file`. "
+            "This is the EndstationBase's `first_find_file`. "
             "While it would be the result of best effort for serching the `first file` in"
             "the directrory, but the resultant file may not agree with what you really expected."
             "Considering the explicit file name specification, or writing your own code to"

--- a/src/arpes/plotting/__init__.py
+++ b/src/arpes/plotting/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "concat_along_phi_ui",
     "cut_dispersion_plot",
     "dark_background",
+    "evolution_movie",
     "fancy_dispersion",
     "fancy_labels",
     "fermi_edge_reference",
@@ -27,11 +29,11 @@ __all__ = [
     "magnify_circular_regions_plot",
     "make_overview",
     "make_reference_plots",
+    "movie",
     "offset_scatter_plot",
     "plot_core_levels",
     "plot_dispersion",
     "plot_dos",
-    "plot_movie",
     "plot_parameter",
     "plot_spatial_reference",
     "plot_with_bands",
@@ -69,7 +71,7 @@ if TYPE_CHECKING:
     from .dos import plot_core_levels, plot_dos
     from .fermi_edge import fermi_edge_reference
     from .fermi_surface import fermi_surface_slices, magnify_circular_regions_plot
-    from .movie import plot_movie
+    from .movie import evolution_movie, movie
     from .parameter import plot_parameter
     from .spatial import plot_spatial_reference, reference_scan_spatial
     from .spin import spin_colored_spectrum, spin_difference_spectrum, spin_polarized_spectrum
@@ -89,65 +91,72 @@ if TYPE_CHECKING:
         profile_view,
     )
     from .utils import fancy_labels, remove_colorbars, savefig, simple_ax_grid
-
-# モジュール名マップ
-_module_map = {
-    "annotate_cuts": "arpes.plotting.annotations",
-    "annotate_experimental_conditions": "arpes.plotting.annotations",
-    "annotate_point": "arpes.plotting.annotations",
-    "plot_with_bands": "arpes.plotting.bands",
-    "make_overview": "arpes.plotting.basic",
-    "make_reference_plots": "arpes.plotting.basic",
-    "dark_background": "arpes.plotting.dark_bg",
-    "h_gradient_fill": "arpes.plotting.decoration",
-    "v_gradient_fill": "arpes.plotting.decoration",
-    "cut_dispersion_plot": "arpes.plotting.dispersion",
-    "fancy_dispersion": "arpes.plotting.dispersion",
-    "hv_reference_scan": "arpes.plotting.dispersion",
-    "labeled_fermi_surface": "arpes.plotting.dispersion",
-    "plot_dispersion": "arpes.plotting.dispersion",
-    "reference_scan_fermi_surface": "arpes.plotting.dispersion",
-    "scan_var_reference_plot": "arpes.plotting.dispersion",
-    "plot_core_levels": "arpes.plotting.dos",
-    "plot_dos": "arpes.plotting.dos",
-    "fermi_edge_reference": "arpes.plotting.fermi_edge",
-    "fermi_surface_slices": "arpes.plotting.fermi_surface",
-    "magnify_circular_regions_plot": "arpes.plotting.fermi_surface",
-    "plot_movie": "arpes.plotting.movie",
-    "plot_parameter": "arpes.plotting.parameter",
-    "plot_spatial_reference": "arpes.plotting.spatial",
-    "reference_scan_spatial": "arpes.plotting.spatial",
-    "spin_colored_spectrum": "arpes.plotting.spin",
-    "spin_difference_spectrum": "arpes.plotting.spin",
-    "spin_polarized_spectrum": "arpes.plotting.spin",
-    "flat_stack_plot": "arpes.plotting.stack_plot",
-    "offset_scatter_plot": "arpes.plotting.stack_plot",
-    "stack_dispersion_plot": "arpes.plotting.stack_plot",
-    "waterfall_dispersion": "arpes.plotting.stack_plot",
-    "DifferentiateApp": "arpes.plotting.ui",
-    "ProfileApp": "arpes.plotting.ui",
-    "SmoothingApp": "arpes.plotting.ui",
-    "TailorApp": "arpes.plotting.ui",
-    "concat_along_phi_ui": "arpes.plotting.ui",
-    "fit_inspection": "arpes.plotting.ui",
-    "profile_view": "arpes.plotting.ui",
-    "fancy_labels": "arpes.plotting.utils",
-    "remove_colorbars": "arpes.plotting.utils",
-    "savefig": "arpes.plotting.utils",
-    "simple_ax_grid": "arpes.plotting.utils",
-}
+# Bind `movie` directly to the package namespace when possible so callers
+# can write `arpes.plotting.movie(...)`. If the import fails during partial
+# initialization, `__getattr__` provides the lazy-import fallback.
+with suppress(Exception):
+    from .movie import movie as movie
 
 
 def __getattr__(name: str) -> Any:  # noqa: ANN401
     """Lazy import for public API.
 
-    Note: The return type is annotated as `Any` because the attributes
-    can be functions, classes, or other objects, and their types vary
-    dynamically at runtime. A static type cannot be determined, so `Any`
-    is necessary to satisfy type checkers.
+    Uses membership in __all__ to validate requested names, then maps the
+    public symbol to the module that provides it. Keeping the mapping
+    inside the function mirrors the pattern used in arpes.analysis and
+    reduces top-level module state.
     """
-    if name not in _module_map:
+    if name not in __all__:
         msg = f"module {__name__} has no attribute {name}"
         raise AttributeError(msg)
-    mod = __import__(_module_map[name], fromlist=[name])
+
+    _module_map = {
+        "annotate_cuts": "arpes.plotting.annotations",
+        "annotate_experimental_conditions": "arpes.plotting.annotations",
+        "annotate_point": "arpes.plotting.annotations",
+        "plot_with_bands": "arpes.plotting.bands",
+        "make_overview": "arpes.plotting.basic",
+        "make_reference_plots": "arpes.plotting.basic",
+        "dark_background": "arpes.plotting.dark_bg",
+        "h_gradient_fill": "arpes.plotting.decoration",
+        "v_gradient_fill": "arpes.plotting.decoration",
+        "cut_dispersion_plot": "arpes.plotting.dispersion",
+        "fancy_dispersion": "arpes.plotting.dispersion",
+        "hv_reference_scan": "arpes.plotting.dispersion",
+        "labeled_fermi_surface": "arpes.plotting.dispersion",
+        "plot_dispersion": "arpes.plotting.dispersion",
+        "reference_scan_fermi_surface": "arpes.plotting.dispersion",
+        "scan_var_reference_plot": "arpes.plotting.dispersion",
+        "plot_core_levels": "arpes.plotting.dos",
+        "plot_dos": "arpes.plotting.dos",
+        "fermi_edge_reference": "arpes.plotting.fermi_edge",
+        "fermi_surface_slices": "arpes.plotting.fermi_surface",
+        "magnify_circular_regions_plot": "arpes.plotting.fermi_surface",
+        "evolution_movie": "arpes.plotting.movie",
+        "movie": "arpes.plotting.movie",
+        "plot_parameter": "arpes.plotting.parameter",
+        "plot_spatial_reference": "arpes.plotting.spatial",
+        "reference_scan_spatial": "arpes.plotting.spatial",
+        "spin_colored_spectrum": "arpes.plotting.spin",
+        "spin_difference_spectrum": "arpes.plotting.spin",
+        "spin_polarized_spectrum": "arpes.plotting.spin",
+        "flat_stack_plot": "arpes.plotting.stack_plot",
+        "offset_scatter_plot": "arpes.plotting.stack_plot",
+        "stack_dispersion_plot": "arpes.plotting.stack_plot",
+        "waterfall_dispersion": "arpes.plotting.stack_plot",
+        "DifferentiateApp": "arpes.plotting.ui",
+        "ProfileApp": "arpes.plotting.ui",
+        "SmoothingApp": "arpes.plotting.ui",
+        "TailorApp": "arpes.plotting.ui",
+        "concat_along_phi_ui": "arpes.plotting.ui",
+        "fit_inspection": "arpes.plotting.ui",
+        "profile_view": "arpes.plotting.ui",
+        "fancy_labels": "arpes.plotting.utils",
+        "remove_colorbars": "arpes.plotting.utils",
+        "savefig": "arpes.plotting.utils",
+        "simple_ax_grid": "arpes.plotting.utils",
+    }
+
+    module_name = _module_map[name]
+    mod = __import__(module_name, fromlist=[name])
     return getattr(mod, name)

--- a/src/arpes/plotting/movie.py
+++ b/src/arpes/plotting/movie.py
@@ -40,7 +40,7 @@ LOGLEVEL = LOGLEVELS[1]
 logger = setup_logger(__name__, LOGLEVEL)
 
 
-__all__ = ("plot_movie", "plot_movie_and_evolution")
+__all__ = ("movie", "plot_movie_and_evolution")
 
 
 def output_animation(  # noqa: PLR0913
@@ -134,7 +134,7 @@ def _configure_axes_and_labels(
 
 
 @save_plot_provenance
-def plot_movie_and_evolution(  # noqa: PLR0913
+def evolution_movie(  # noqa: PLR0913
     data: xr.DataArray,
     *,
     time_dim: str = "delay",
@@ -279,7 +279,7 @@ def plot_movie_and_evolution(  # noqa: PLR0913
 
 
 @save_plot_provenance
-def plot_movie(  # noqa: PLR0913
+def movie(  # noqa: PLR0913
     data: xr.DataArray,
     *,
     time_dim: str = "delay",
@@ -417,3 +417,10 @@ def _replace_after_row(array: NDArray[np.floating], row_num: int) -> NDArray[np.
         NDArray[np.floating]: The modified array with NaN values after the specified row.
     """
     return np.where(np.arange(array.shape[0])[:, None] >= row_num, np.nan, array)
+
+
+# Backwards-compatible aliases
+# The public function was renamed to `movie` for conciseness; provide aliases
+# so existing call sites continue to work until callers are migrated.
+plot_movie = movie
+plot_movie_and_evolution = evolution_movie

--- a/src/arpes/xarray_extensions/accessor/general.py
+++ b/src/arpes/xarray_extensions/accessor/general.py
@@ -13,7 +13,7 @@ import xarray as xr
 from arpes.analysis.value_transform import apply_dataarray
 from arpes.correction import coords, intensity_map
 from arpes.debug import setup_logger
-from arpes.plotting.movie import plot_movie
+from arpes.plotting.movie import movie
 
 if TYPE_CHECKING:
     from collections.abc import (
@@ -613,7 +613,7 @@ class GenericDataArrayAccessor(GenericAccessorBase[xr.DataArray]):
         """
         assert isinstance(self._obj, xr.DataArray)
 
-        return plot_movie(self._obj, time_dim=time_dim, out=out, **kwargs)
+        return movie(self._obj, time_dim=time_dim, out=out, **kwargs)
 
     def map_axes(
         self,

--- a/tests/test_tarpes.py
+++ b/tests/test_tarpes.py
@@ -14,7 +14,7 @@ from arpes.analysis import tarpes
 from arpes.plotting.movie import (
     _replace_after_col,
     _replace_after_row,
-    plot_movie,
+    movie,
     plot_movie_and_evolution,
 )
 
@@ -292,7 +292,7 @@ def test_plot_movie_and_evolution_is_subtracted_true_with_labels(another_sample_
     """Test when data.S.is_subtracted is True and labels are provided."""
     another_sample_data.attrs["subtracted"] = True
     labels = ("Custom X-axis", "Custom Y-axis")
-    result = plot_movie(
+    result = movie(
         data=another_sample_data,
         labels=labels,
         out=None,  # Return HTML


### PR DESCRIPTION
This pull request introduces a breaking API change to the ARPES plotting module, specifically renaming the main movie creation function for improved clarity and convenience. The function formerly known as `plot_movie` is now simply called `movie`, and all references throughout the codebase and documentation have been updated accordingly. Backwards-compatible aliases are provided to ease migration, but users are encouraged to update their imports. Additional minor improvements and bugfixes are also included.

**Plotting API changes:**
* Renamed the main movie creation function from `plot_movie` to `movie` in `arpes.plotting.movie`, allowing direct calls as `arpes.plotting.movie(...)`. Backwards-compatible aliases (`plot_movie`) remain for now, but clients should migrate to the new name. (`[[1]](diffhunk://#diff-fb9b9dfe5191a51d9d16f8080fa2e339239957f100682eabe13a7ea606eecbeeL282-R282)`, `[[2]](diffhunk://#diff-fb9b9dfe5191a51d9d16f8080fa2e339239957f100682eabe13a7ea606eecbeeR420-R426)`, `[[3]](diffhunk://#diff-1713470a50686538a24f6e0c4e34d3b7ea24059b0ab0818273fdfe4896bb2579R42-R54)`)
* Updated all imports and references in the codebase and tests to use the new `movie` name instead of `plot_movie`. (`[[1]](diffhunk://#diff-e4d9f95a4ff5ce34d2e826cea22f53b19e819b04705c167f63f69d4085417c31L16-R16)`, `[[2]](diffhunk://#diff-e4d9f95a4ff5ce34d2e826cea22f53b19e819b04705c167f63f69d4085417c31L616-R616)`, `[[3]](diffhunk://#diff-49ee01694850fa5c15754f131397507c2a05b9c1fe3e05cc6e16e5c3dc0df8d6L17-R17)`, `[[4]](diffhunk://#diff-49ee01694850fa5c15754f131397507c2a05b9c1fe3e05cc6e16e5c3dc0df8d6L295-R295)`)
* Improved the `__init__.py` of `arpes.plotting` to bind `movie` directly to the package namespace, support lazy imports, and update `__all__` and module mappings accordingly. (`[[1]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R5)`, `[[2]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R19)`, `[[3]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R32-L34)`, `[[4]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4L72-R74)`, `[[5]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R94-L93)`, `[[6]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4L116-R136)`, `[[7]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4L140-R161)`)

**Other improvements:**
* Renamed `plot_movie_and_evolution` to `evolution_movie` for clarity, with a backwards-compatible alias. (`[[1]](diffhunk://#diff-fb9b9dfe5191a51d9d16f8080fa2e339239957f100682eabe13a7ea606eecbeeL137-R137)`, `[[2]](diffhunk://#diff-fb9b9dfe5191a51d9d16f8080fa2e339239957f100682eabe13a7ea606eecbeeR420-R426)`)
* Fixed a typo in a warning message in the `find_first_file` method of `EndstationBase`. (`[src/arpes/endstations/base.pyL185-R185](diffhunk://#diff-eb3e04f6fedab0ace55ef65003eed7ae155334c8c84463bb7dbd9c45e10d7110L185-R185)`)
* Allowed the `rectangle_phis` argument in `trapezoid` to accept tuples as well as lists, improving flexibility. (`[[1]](diffhunk://#diff-41a5f0b04b747f2218db8f7b1437aa5bb4baf736c35c0823953ad782d0daa91bL289-R289)`, `[[2]](diffhunk://#diff-41a5f0b04b747f2218db8f7b1437aa5bb4baf736c35c0823953ad782d0daa91bL355-R355)`)

Please update your code to use the new `movie` function name when creating movies with ARPES data. Backwards-compatible aliases are provided for now, but will be removed in a future release.…nd add evolution_movie alias)

* Rename function plot_movie to movie and update all/imports/tests.
  * Add package-level arpes.plotting.movie convenience bind
  * Expose evolution_movie at package top-level and add backwards-compatible aliases.
  * Update xarray accessor and tests to call movie.
  * Minor init lazy-import refactor for consistency with arpes.analysis.