### PR TITLE
refactoring movie.py

### DIFF
--- a/src/arpes/plotting/__init__.py
+++ b/src/arpes/plotting/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "make_reference_plots",
     "movie",
     "offset_scatter_plot",
+    "output_animation",
     "plot_core_levels",
     "plot_dispersion",
     "plot_dos",
@@ -52,7 +53,7 @@ __all__ = [
     "waterfall_dispersion",
 ]
 
-# TYPE_CHECKING 用に明示的インポート
+#
 if TYPE_CHECKING:
     from .annotations import annotate_cuts, annotate_experimental_conditions, annotate_point
     from .bands import plot_with_bands
@@ -91,6 +92,7 @@ if TYPE_CHECKING:
         profile_view,
     )
     from .utils import fancy_labels, remove_colorbars, savefig, simple_ax_grid
+
 # Bind `movie` directly to the package namespace when possible so callers
 # can write `arpes.plotting.movie(...)`. If the import fails during partial
 # initialization, `__getattr__` provides the lazy-import fallback.
@@ -134,6 +136,7 @@ def __getattr__(name: str) -> Any:  # noqa: ANN401
         "magnify_circular_regions_plot": "arpes.plotting.fermi_surface",
         "evolution_movie": "arpes.plotting.movie",
         "movie": "arpes.plotting.movie",
+        "output_animation": "arpes.plotting.movie",
         "plot_parameter": "arpes.plotting.parameter",
         "plot_spatial_reference": "arpes.plotting.spatial",
         "reference_scan_spatial": "arpes.plotting.spatial",

--- a/src/arpes/plotting/__init__.py
+++ b/src/arpes/plotting/__init__.py
@@ -53,7 +53,6 @@ __all__ = [
     "waterfall_dispersion",
 ]
 
-#
 if TYPE_CHECKING:
     from .annotations import annotate_cuts, annotate_experimental_conditions, annotate_point
     from .bands import plot_with_bands

--- a/src/arpes/plotting/movie.py
+++ b/src/arpes/plotting/movie.py
@@ -40,7 +40,7 @@ LOGLEVEL = LOGLEVELS[1]
 logger = setup_logger(__name__, LOGLEVEL)
 
 
-__all__ = ("movie", "plot_movie_and_evolution")
+__all__ = ("movie", "output_animation", "plot_movie_and_evolution")
 
 
 def output_animation(  # noqa: PLR0913

--- a/src/arpes/plotting/stack_plot.py
+++ b/src/arpes/plotting/stack_plot.py
@@ -18,7 +18,6 @@ from matplotlib.colors import Colormap
 from matplotlib.ticker import FixedLocator, MaxNLocator
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
-from arpes._typing.plotting import MPLPlotKwargsBasic
 from arpes.analysis import rebin
 from arpes.constants import TWO_DIMENSION
 from arpes.debug import setup_logger


### PR DESCRIPTION
This pull request primarily updates the `arpes.plotting` package to expose the `output_animation` function at the top-level API, making it easier for users to access. It also cleans up some import statements and updates the `__all__` variable in `movie.py` to include the new function.

**API Improvements:**

* Exposed `output_animation` in the top-level `arpes.plotting` namespace by adding it to the `__all__` list and the dynamic import logic in `__getattr__`. This allows users to call `arpes.plotting.output_animation` directly. [[1]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R34) [[2]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R139) [[3]](diffhunk://#diff-fb9b9dfe5191a51d9d16f8080fa2e339239957f100682eabe13a7ea606eecbeeL43-R43)

**Code Clean-up:**

* Removed an unused import of `MPLPlotKwargsBasic` from `stack_plot.py`.
* Minor formatting and comment clean-up in `__init__.py` for clarity. [[1]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4L55-R56) [[2]](diffhunk://#diff-410561d1001ed116358c1e444d8209096c476eb6e78392b11b5b5091be669cc4R95)